### PR TITLE
[P2-003] 語音訊息 Audio Event 處理與 STT 解析

### DIFF
--- a/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IValidationReplyService.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IValidationReplyService.cs
@@ -1,0 +1,6 @@
+namespace VeggieAlly.Application.Common.Interfaces;
+
+public interface IValidationReplyService
+{
+    Task ProcessLlmResponseAndReplyAsync(string? llmResponse, string replyToken, CancellationToken ct = default);
+}

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageCommand.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using VeggieAlly.Domain.Models.Line;
+
+namespace VeggieAlly.Application.LineEvents.ProcessAudio;
+
+public sealed record ProcessAudioMessageCommand(LineEvent Event) : IRequest;

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs
@@ -1,0 +1,104 @@
+using MediatR;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Application.Prompts;
+using VeggieAlly.Domain.Abstractions;
+
+namespace VeggieAlly.Application.LineEvents.ProcessAudio;
+
+public sealed class ProcessAudioMessageHandler : IRequestHandler<ProcessAudioMessageCommand>
+{
+    private readonly IChatClient _chatClient;
+    private readonly ILineReplyService _lineReplyService;
+    private readonly ILineContentService _lineContentService;
+    private readonly IValidationReplyService _validationReplyService;
+    private readonly ILogger<ProcessAudioMessageHandler> _logger;
+
+    public ProcessAudioMessageHandler(
+        IChatClient chatClient,
+        ILineReplyService lineReplyService,
+        ILineContentService lineContentService,
+        IValidationReplyService validationReplyService,
+        ILogger<ProcessAudioMessageHandler> logger)
+    {
+        _chatClient = chatClient;
+        _lineReplyService = lineReplyService;
+        _lineContentService = lineContentService;
+        _validationReplyService = validationReplyService;
+        _logger = logger;
+    }
+
+    public async Task Handle(ProcessAudioMessageCommand request, CancellationToken cancellationToken)
+    {
+        var messageId = request.Event.Message?.Id;
+        var replyToken = request.Event.ReplyToken;
+
+        if (string.IsNullOrWhiteSpace(replyToken))
+        {
+            _logger.LogWarning("ReplyToken 為空，無法回覆");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(messageId))
+        {
+            _logger.LogWarning("語音訊息 ID 為空");
+            await SafeReplyAsync(replyToken, "語音下載失敗，請重新錄音", cancellationToken);
+            return;
+        }
+
+        // ── Step 1: 下載語音檔 ──
+        byte[] audioBytes;
+        try
+        {
+            audioBytes = await _lineContentService.DownloadContentAsync(messageId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "LINE Content API 下載語音失敗: MessageId={MessageId}", messageId);
+            await SafeReplyAsync(replyToken, "語音下載失敗，請重新錄音", cancellationToken);
+            return;
+        }
+
+        if (audioBytes.Length == 0)
+        {
+            _logger.LogWarning("下載的語音內容為空: MessageId={MessageId}", messageId);
+            await SafeReplyAsync(replyToken, "語音內容為空，請重新錄音", cancellationToken);
+            return;
+        }
+
+        // ── Step 2: Gemini 多模態 STT + 結構化解析 ──
+        try
+        {
+            var audioContent = new DataContent(audioBytes, "audio/m4a");
+            var messages = new ChatMessage[]
+            {
+                new(ChatRole.System, SystemPrompts.VegetableParser),
+                new(ChatRole.User, new List<AIContent> { audioContent })
+            };
+
+            var completion = await _chatClient.GetResponseAsync(messages, cancellationToken: cancellationToken);
+            var llmResponse = completion?.Text?.Trim();
+
+            await _validationReplyService.ProcessLlmResponseAndReplyAsync(llmResponse, replyToken, cancellationToken);
+            _logger.LogInformation("成功處理語音訊息並回覆");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Gemini API 呼叫失敗");
+            await SafeReplyAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);
+        }
+    }
+
+    private async Task SafeReplyAsync(string replyToken, string text, CancellationToken ct)
+    {
+        try
+        {
+            await _lineReplyService.ReplyTextAsync(replyToken, text, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "LINE Reply 失敗，無法回覆使用者");
+        }
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs
@@ -1,13 +1,9 @@
-using System.Text;
-using System.Text.Json;
 using MediatR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using VeggieAlly.Application.Common.Interfaces;
 using VeggieAlly.Application.Prompts;
 using VeggieAlly.Domain.Abstractions;
-using VeggieAlly.Domain.Models.Parsing;
-using VeggieAlly.Domain.ValueObjects;
 
 namespace VeggieAlly.Application.LineEvents.ProcessText;
 
@@ -15,24 +11,18 @@ public sealed class ProcessTextMessageHandler : IRequestHandler<ProcessTextMessa
 {
     private readonly IChatClient _chatClient;
     private readonly ILineReplyService _lineReplyService;
-    private readonly IVegetablePricingService _pricingService;
-    private readonly IPriceValidationService _validationService;
-    private readonly IFlexMessageBuilder _flexMessageBuilder;
+    private readonly IValidationReplyService _validationReplyService;
     private readonly ILogger<ProcessTextMessageHandler> _logger;
 
     public ProcessTextMessageHandler(
         IChatClient chatClient,
         ILineReplyService lineReplyService,
-        IVegetablePricingService pricingService,
-        IPriceValidationService validationService,
-        IFlexMessageBuilder flexMessageBuilder,
+        IValidationReplyService validationReplyService,
         ILogger<ProcessTextMessageHandler> logger)
     {
         _chatClient = chatClient;
         _lineReplyService = lineReplyService;
-        _pricingService = pricingService;
-        _validationService = validationService;
-        _flexMessageBuilder = flexMessageBuilder;
+        _validationReplyService = validationReplyService;
         _logger = logger;
     }
 
@@ -52,9 +42,6 @@ public sealed class ProcessTextMessageHandler : IRequestHandler<ProcessTextMessa
             return;
         }
 
-        // ── Step 1: 呼叫 Gemini API ──
-        List<ValidatedVegetableItem>? validatedItems = null;
-        string? fallbackText = null;
         try
         {
             var messages = new ChatMessage[]
@@ -64,171 +51,22 @@ public sealed class ProcessTextMessageHandler : IRequestHandler<ProcessTextMessa
             };
 
             var completion = await _chatClient.GetResponseAsync(messages, cancellationToken: cancellationToken);
-            var responseContent = completion?.Text?.Trim();
+            var llmResponse = completion?.Text?.Trim();
 
-            // LLM 有時會用 markdown 代碼框包裹 JSON，去除之
-            responseContent = StripMarkdownCodeFence(responseContent);
-
-            if (string.IsNullOrWhiteSpace(responseContent))
-            {
-                _logger.LogWarning("Gemini 回傳空內容");
-                fallbackText = "解析失敗，請重新輸入";
-            }
-            else if (!IsValidJson(responseContent))
-            {
-                _logger.LogWarning("Gemini 回傳非 JSON 格式: {Content}", responseContent);
-                fallbackText = "解析失敗，請重新輸入";
-            }
-            else
-            {
-                // ── Step 1.5: 解析 JSON 並進行價格驗證 ──
-                validatedItems = await ProcessValidationAsync(responseContent, cancellationToken);
-                if (validatedItems is null)
-                    fallbackText = "解析失敗，請重新輸入";
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Gemini API 呼叫失敗");
-            fallbackText = "系統忙碌中，請稍後重試";
-        }
-
-        // ── Step 2: 回覆 LINE 使用者（獨立 try-catch） ──
-        try
-        {
-            if (validatedItems is not null)
-            {
-                try
-                {
-                    var bubble = _flexMessageBuilder.BuildBubble(validatedItems);
-                    var okCount = validatedItems.Count(i => i.Validation.Status == ValidationStatus.Ok);
-                    var anomalyCount = validatedItems.Count - okCount;
-                    var altText = $"📋 報價驗證結果：{okCount}項正常, {anomalyCount}項異常";
-                    await _lineReplyService.ReplyFlexAsync(replyToken, altText, bubble, cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Flex Message 建構失敗，降級為純文字回覆");
-                    await _lineReplyService.ReplyTextAsync(replyToken, GenerateValidationReply(validatedItems), cancellationToken);
-                }
-            }
-            else
-            {
-                await _lineReplyService.ReplyTextAsync(replyToken, fallbackText!, cancellationToken);
-            }
+            await _validationReplyService.ProcessLlmResponseAndReplyAsync(llmResponse, replyToken, cancellationToken);
             _logger.LogInformation("成功處理文字訊息並回覆");
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "LINE Reply 失敗，無法回覆使用者");
-        }
-    }
-
-    private async Task<List<ValidatedVegetableItem>?> ProcessValidationAsync(string jsonContent, CancellationToken cancellationToken)
-    {
-        try
-        {
-            // 反序列化為物件（items 陣列）
-            var parseResult = JsonSerializer.Deserialize<ParseResult>(jsonContent, new JsonSerializerOptions
+            _logger.LogError(ex, "Gemini API 呼叫失敗");
+            try
             {
-                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-            });
-
-            if (parseResult?.Items == null || parseResult.Items.Count == 0)
-            {
-                _logger.LogWarning("JSON 反序列化成功但無有效品項");
-                return null;
+                await _lineReplyService.ReplyTextAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);
             }
-
-            // 走訪每個 item，查歷史價 + 驗證
-            var validatedItems = new List<ValidatedVegetableItem>();
-            
-            foreach (var item in parseResult.Items)
+            catch (Exception replyEx)
             {
-                // 查詢歷史價格
-                var historicalPrice = await _pricingService.GetHistoricalAvgPriceAsync(item.Name, cancellationToken: cancellationToken);
-                
-                // 執行價格驗證
-                var validation = _validationService.Validate(item.BuyPrice, item.SellPrice, historicalPrice);
-                
-                // 組合為 ValidatedVegetableItem
-                var validatedItem = new ValidatedVegetableItem(
-                    item.Name,
-                    item.IsNew,
-                    item.BuyPrice,
-                    item.SellPrice,
-                    item.Quantity,
-                    item.Unit,
-                    historicalPrice,
-                    validation
-                );
-                
-                validatedItems.Add(validatedItem);
+                _logger.LogWarning(replyEx, "LINE Reply 失敗，無法回覆使用者");
             }
-
-            // 產生回覆文字：用 🟢/🔴 標示每個品項的驗證結果
-            return validatedItems;
         }
-        catch (JsonException ex)
-        {
-            _logger.LogError(ex, "JSON 反序列化失敗: {Json}", jsonContent);
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "價格驗證過程發生錯誤");
-            return null;
-        }
-    }
-
-    private static string GenerateValidationReply(List<ValidatedVegetableItem> validatedItems)
-    {
-        var reply = new StringBuilder("📋 報價驗證結果：\n");
-
-        foreach (var item in validatedItems)
-        {
-            var icon = item.Validation.Status == ValidationStatus.Ok ? "🟢" : "🔴";
-            var warning = item.Validation.Status != ValidationStatus.Ok && !string.IsNullOrEmpty(item.Validation.Message)
-                ? $" ⚠️ {item.Validation.Message}"
-                : "";
-
-            reply.AppendLine($"{icon} {item.Name}｜進${item.BuyPrice} 售${item.SellPrice} x{item.Quantity}{item.Unit}{warning}");
-        }
-
-        return reply.ToString();
-    }
-
-    private static bool IsValidJson(string text)
-    {
-        try
-        {
-            using var doc = JsonDocument.Parse(text);
-            return true;
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
-
-    private static string? StripMarkdownCodeFence(string? text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return text;
-
-        var trimmed = text.Trim();
-        if (trimmed.StartsWith("```"))
-        {
-            // 去除第一行 ```json 或 ```
-            var firstNewLine = trimmed.IndexOf('\n');
-            if (firstNewLine >= 0)
-                trimmed = trimmed[(firstNewLine + 1)..];
-
-            // 去除最後的 ```
-            if (trimmed.EndsWith("```"))
-                trimmed = trimmed[..^3].TrimEnd();
-        }
-
-        return trimmed;
     }
 }

--- a/VeggieAlly/src/VeggieAlly.Application/Services/ValidationReplyService.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/ValidationReplyService.cs
@@ -1,0 +1,173 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Domain.Abstractions;
+using VeggieAlly.Domain.Models.Parsing;
+using VeggieAlly.Domain.ValueObjects;
+
+namespace VeggieAlly.Application.Services;
+
+public sealed class ValidationReplyService : IValidationReplyService
+{
+    private readonly ILineReplyService _lineReplyService;
+    private readonly IVegetablePricingService _pricingService;
+    private readonly IPriceValidationService _validationService;
+    private readonly IFlexMessageBuilder _flexMessageBuilder;
+    private readonly ILogger<ValidationReplyService> _logger;
+
+    public ValidationReplyService(
+        ILineReplyService lineReplyService,
+        IVegetablePricingService pricingService,
+        IPriceValidationService validationService,
+        IFlexMessageBuilder flexMessageBuilder,
+        ILogger<ValidationReplyService> logger)
+    {
+        _lineReplyService = lineReplyService;
+        _pricingService = pricingService;
+        _validationService = validationService;
+        _flexMessageBuilder = flexMessageBuilder;
+        _logger = logger;
+    }
+
+    public async Task ProcessLlmResponseAndReplyAsync(string? llmResponse, string replyToken, CancellationToken ct = default)
+    {
+        var responseContent = StripMarkdownCodeFence(llmResponse);
+
+        List<ValidatedVegetableItem>? validatedItems = null;
+        string? fallbackText = null;
+
+        if (string.IsNullOrWhiteSpace(responseContent))
+        {
+            _logger.LogWarning("LLM 回傳空內容");
+            fallbackText = "解析失敗，請重新輸入";
+        }
+        else if (!IsValidJson(responseContent))
+        {
+            _logger.LogWarning("LLM 回傳非 JSON 格式: {Content}", responseContent);
+            fallbackText = "解析失敗，請重新輸入";
+        }
+        else
+        {
+            validatedItems = await ProcessValidationAsync(responseContent, ct);
+            if (validatedItems is null)
+                fallbackText = "解析失敗，請重新輸入";
+        }
+
+        try
+        {
+            if (validatedItems is not null)
+            {
+                try
+                {
+                    var bubble = _flexMessageBuilder.BuildBubble(validatedItems);
+                    var okCount = validatedItems.Count(i => i.Validation.Status == ValidationStatus.Ok);
+                    var anomalyCount = validatedItems.Count - okCount;
+                    var altText = $"📋 報價驗證結果：{okCount}項正常, {anomalyCount}項異常";
+                    await _lineReplyService.ReplyFlexAsync(replyToken, altText, bubble, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Flex Message 建構失敗，降級為純文字回覆");
+                    await _lineReplyService.ReplyTextAsync(replyToken, GenerateValidationReply(validatedItems), ct);
+                }
+            }
+            else
+            {
+                await _lineReplyService.ReplyTextAsync(replyToken, fallbackText!, ct);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "LINE Reply 失敗，無法回覆使用者");
+        }
+    }
+
+    private async Task<List<ValidatedVegetableItem>?> ProcessValidationAsync(string jsonContent, CancellationToken ct)
+    {
+        try
+        {
+            var parseResult = JsonSerializer.Deserialize<ParseResult>(jsonContent, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+            });
+
+            if (parseResult?.Items == null || parseResult.Items.Count == 0)
+            {
+                _logger.LogWarning("JSON 反序列化成功但無有效品項");
+                return null;
+            }
+
+            var validatedItems = new List<ValidatedVegetableItem>();
+
+            foreach (var item in parseResult.Items)
+            {
+                var historicalPrice = await _pricingService.GetHistoricalAvgPriceAsync(item.Name, cancellationToken: ct);
+                var validation = _validationService.Validate(item.BuyPrice, item.SellPrice, historicalPrice);
+                var validatedItem = new ValidatedVegetableItem(
+                    item.Name, item.IsNew, item.BuyPrice, item.SellPrice,
+                    item.Quantity, item.Unit, historicalPrice, validation);
+                validatedItems.Add(validatedItem);
+            }
+
+            return validatedItems;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "JSON 反序列化失敗: {Json}", jsonContent);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "價格驗證過程發生錯誤");
+            return null;
+        }
+    }
+
+    internal static string GenerateValidationReply(List<ValidatedVegetableItem> validatedItems)
+    {
+        var reply = new StringBuilder("📋 報價驗證結果：\n");
+
+        foreach (var item in validatedItems)
+        {
+            var icon = item.Validation.Status == ValidationStatus.Ok ? "🟢" : "🔴";
+            var warning = item.Validation.Status != ValidationStatus.Ok && !string.IsNullOrEmpty(item.Validation.Message)
+                ? $" ⚠️ {item.Validation.Message}"
+                : "";
+            reply.AppendLine($"{icon} {item.Name}｜進${item.BuyPrice} 售${item.SellPrice} x{item.Quantity}{item.Unit}{warning}");
+        }
+
+        return reply.ToString();
+    }
+
+    internal static string? StripMarkdownCodeFence(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return text;
+
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith("```"))
+        {
+            var firstNewLine = trimmed.IndexOf('\n');
+            if (firstNewLine >= 0)
+                trimmed = trimmed[(firstNewLine + 1)..];
+            if (trimmed.EndsWith("```"))
+                trimmed = trimmed[..^3].TrimEnd();
+        }
+
+        return trimmed;
+    }
+
+    private static bool IsValidJson(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Domain/Abstractions/ILineContentService.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Abstractions/ILineContentService.cs
@@ -1,0 +1,6 @@
+namespace VeggieAlly.Domain.Abstractions;
+
+public interface ILineContentService
+{
+    Task<byte[]> DownloadContentAsync(string messageId, CancellationToken ct = default);
+}

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/DependencyInjection.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/DependencyInjection.cs
@@ -23,6 +23,10 @@ public static class DependencyInjection
         {
             client.BaseAddress = new Uri("https://api.line.me");
         });
+        services.AddHttpClient<ILineContentService, LineContentService>((sp, client) =>
+        {
+            client.BaseAddress = new Uri("https://api-data.line.me");
+        });
 
         // ── AI: 根據 AI:Provider 切換後端 ──
         var aiProvider = configuration.GetValue<string>("AI:Provider") ?? "gemini";
@@ -56,6 +60,9 @@ public static class DependencyInjection
 
         // ── Flex Message Builder ──
         services.AddSingleton<IFlexMessageBuilder, FlexMessageBuilder>();
+
+        // ── Validation Reply Pipeline ──
+        services.AddScoped<IValidationReplyService, ValidationReplyService>();
 
         return services;
     }

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Line/LineContentService.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Line/LineContentService.cs
@@ -1,0 +1,32 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using VeggieAlly.Domain.Abstractions;
+
+namespace VeggieAlly.Infrastructure.Line;
+
+public sealed class LineContentService : ILineContentService
+{
+    private readonly HttpClient _httpClient;
+    private readonly LineOptions _options;
+    private readonly ILogger<LineContentService> _logger;
+
+    public LineContentService(HttpClient httpClient, IOptions<LineOptions> options, ILogger<LineContentService> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<byte[]> DownloadContentAsync(string messageId, CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/v2/bot/message/{messageId}/content");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ChannelAccessToken);
+
+        var response = await _httpClient.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+
+        _logger.LogInformation("成功下載語音內容: MessageId={MessageId}", messageId);
+        return await response.Content.ReadAsByteArrayAsync(ct);
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/WebhookController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/WebhookController.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using VeggieAlly.Application.LineEvents.ProcessAudio;
 using VeggieAlly.Application.LineEvents.ProcessText;
 using VeggieAlly.Domain.Models.Line;
 using VeggieAlly.WebAPI.Filters;
@@ -31,11 +32,9 @@ public sealed class WebhookController : ControllerBase
 
         foreach (var lineEvent in payload.Events)
         {
-            // 過濾條件：僅處理 message 類型的 text 事件
-            if (lineEvent.Type != "message" || lineEvent.Message?.Type != "text")
+            if (lineEvent.Type != "message")
             {
-                _logger.LogDebug("跳過非文字訊息事件: Type={EventType}, MessageType={MessageType}", 
-                    lineEvent.Type, lineEvent.Message?.Type);
+                _logger.LogDebug("跳過非 message 事件: Type={EventType}", lineEvent.Type);
                 continue;
             }
 
@@ -48,9 +47,20 @@ public sealed class WebhookController : ControllerBase
 
             try
             {
-                var command = new ProcessTextMessageCommand(lineEvent);
-                await _mediator.Send(command);
-                _logger.LogInformation("成功處理文字訊息事件");
+                switch (lineEvent.Message?.Type)
+                {
+                    case "text":
+                        await _mediator.Send(new ProcessTextMessageCommand(lineEvent));
+                        _logger.LogInformation("成功處理文字訊息事件");
+                        break;
+                    case "audio":
+                        await _mediator.Send(new ProcessAudioMessageCommand(lineEvent));
+                        _logger.LogInformation("成功處理語音訊息事件");
+                        break;
+                    default:
+                        _logger.LogDebug("跳過不支援的訊息類型: {MessageType}", lineEvent.Message?.Type);
+                        break;
+                }
             }
             catch (Exception ex)
             {

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/ProcessAudioMessageHandlerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/ProcessAudioMessageHandlerTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Application.LineEvents.ProcessAudio;
+using VeggieAlly.Domain.Abstractions;
+using VeggieAlly.Domain.Models.Line;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class ProcessAudioMessageHandlerTests
+{
+    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly ILineReplyService _lineReplyService = Substitute.For<ILineReplyService>();
+    private readonly ILineContentService _lineContentService = Substitute.For<ILineContentService>();
+    private readonly IValidationReplyService _validationReplyService = Substitute.For<IValidationReplyService>();
+    private readonly ILogger<ProcessAudioMessageHandler> _logger = Substitute.For<ILogger<ProcessAudioMessageHandler>>();
+    private readonly ProcessAudioMessageHandler _handler;
+
+    public ProcessAudioMessageHandlerTests()
+    {
+        _handler = new ProcessAudioMessageHandler(_chatClient, _lineReplyService, _lineContentService, _validationReplyService, _logger);
+    }
+
+    private static ProcessAudioMessageCommand CreateCommand(
+        string? messageId = "audio-msg-001",
+        string? replyToken = "reply-token-123")
+    {
+        var lineEvent = new LineEvent(
+            Type: "message",
+            ReplyToken: replyToken,
+            Source: new LineEventSource("user", "U123"),
+            Message: new LineMessage(messageId!, "audio", null));
+        return new ProcessAudioMessageCommand(lineEvent);
+    }
+
+    private void SetupAudioDownload(byte[]? audioBytes = null)
+    {
+        _lineContentService.DownloadContentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(audioBytes ?? new byte[] { 0x01, 0x02, 0x03 });
+    }
+
+    private void SetupLlmReturns(string content)
+    {
+        _chatClient.GetResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, content)));
+    }
+
+    [Fact]
+    public async Task Handle_ValidAudio_DownloadsAndCallsValidationService()
+    {
+        SetupAudioDownload();
+        SetupLlmReturns("{\"items\":[]}");
+        var command = CreateCommand();
+
+        await _handler.Handle(command, default);
+
+        await _lineContentService.Received(1).DownloadContentAsync("audio-msg-001", default);
+        await _chatClient.Received(1).GetResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
+            default);
+        await _validationReplyService.Received(1).ProcessLlmResponseAndReplyAsync(
+            "{\"items\":[]}",
+            "reply-token-123",
+            default);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyReplyToken_DoesNotProcess()
+    {
+        var command = CreateCommand(replyToken: "");
+
+        await _handler.Handle(command, default);
+
+        await _lineContentService.DidNotReceive().DownloadContentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EmptyMessageId_RepliesError()
+    {
+        var lineEvent = new LineEvent(
+            Type: "message",
+            ReplyToken: "reply-token-123",
+            Source: new LineEventSource("user", "U123"),
+            Message: new LineMessage("", "audio", null));
+        var command = new ProcessAudioMessageCommand(lineEvent);
+
+        await _handler.Handle(command, default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync(
+            "reply-token-123",
+            "語音下載失敗，請重新錄音",
+            default);
+    }
+
+    [Fact]
+    public async Task Handle_ContentDownloadFails_RepliesDownloadError()
+    {
+        _lineContentService.DownloadContentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Download failed"));
+        var command = CreateCommand();
+
+        await _handler.Handle(command, default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync(
+            "reply-token-123",
+            "語音下載失敗，請重新錄音",
+            default);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyAudioBytes_RepliesEmptyError()
+    {
+        SetupAudioDownload(Array.Empty<byte>());
+        var command = CreateCommand();
+
+        await _handler.Handle(command, default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync(
+            "reply-token-123",
+            "語音內容為空，請重新錄音",
+            default);
+    }
+
+    [Fact]
+    public async Task Handle_LlmThrows_RepliesBusyMessage()
+    {
+        SetupAudioDownload();
+        _chatClient.GetResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Gemini error"));
+        var command = CreateCommand();
+
+        await _handler.Handle(command, default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync(
+            "reply-token-123",
+            "系統忙碌中，請稍後重試",
+            default);
+    }
+
+    [Fact]
+    public async Task Handle_SafeReplyThrows_DoesNotThrow()
+    {
+        _lineContentService.DownloadContentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Download failed"));
+        _lineReplyService.ReplyTextAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Reply failed too"));
+        var command = CreateCommand();
+
+        await _handler.Handle(command, default);
+
+        // Should complete without throwing
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/ProcessTextMessageHandlerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/ProcessTextMessageHandlerTests.cs
@@ -6,7 +6,6 @@ using VeggieAlly.Application.Common.Interfaces;
 using VeggieAlly.Application.LineEvents.ProcessText;
 using VeggieAlly.Domain.Abstractions;
 using VeggieAlly.Domain.Models.Line;
-using VeggieAlly.Domain.ValueObjects;
 
 namespace VeggieAlly.Application.Tests;
 
@@ -14,17 +13,13 @@ public sealed class ProcessTextMessageHandlerTests
 {
     private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
     private readonly ILineReplyService _lineReplyService = Substitute.For<ILineReplyService>();
-    private readonly IVegetablePricingService _pricingService = Substitute.For<IVegetablePricingService>();
-    private readonly IPriceValidationService _validationService = Substitute.For<IPriceValidationService>();
-    private readonly IFlexMessageBuilder _flexMessageBuilder = Substitute.For<IFlexMessageBuilder>();
+    private readonly IValidationReplyService _validationReplyService = Substitute.For<IValidationReplyService>();
     private readonly ILogger<ProcessTextMessageHandler> _logger = Substitute.For<ILogger<ProcessTextMessageHandler>>();
     private readonly ProcessTextMessageHandler _handler;
 
-    private const string ValidJson = """{"items":[{"name":"初秋高麗菜","is_new":false,"buy_price":25,"sell_price":35,"quantity":50,"unit":"箱"}]}""";
-
     public ProcessTextMessageHandlerTests()
     {
-        _handler = new ProcessTextMessageHandler(_chatClient, _lineReplyService, _pricingService, _validationService, _flexMessageBuilder, _logger);
+        _handler = new ProcessTextMessageHandler(_chatClient, _lineReplyService, _validationReplyService, _logger);
     }
 
     private static ProcessTextMessageCommand CreateCommand(
@@ -48,106 +43,17 @@ public sealed class ProcessTextMessageHandlerTests
             .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, content)));
     }
 
-    private void SetupOkValidation()
-    {
-        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(26m);
-        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
-        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
-            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
-    }
-
     [Fact]
-    public async Task Handle_ValidTextOkValidation_CallsReplyFlexAsync()
+    public async Task Handle_ValidText_CallsValidationReplyService()
     {
-        // Arrange
-        SetupChatClientReturns(ValidJson);
-        SetupOkValidation();
+        SetupChatClientReturns("{\"items\":[]}");
         var command = CreateCommand();
 
-        // Act
         await _handler.Handle(command, default);
 
-        // Assert — now uses ReplyFlexAsync instead of ReplyTextAsync
-        await _lineReplyService.Received(1).ReplyFlexAsync(
+        await _validationReplyService.Received(1).ProcessLlmResponseAndReplyAsync(
+            "{\"items\":[]}",
             "reply-token-123",
-            Arg.Is<string>(alt => alt.Contains("1項正常")),
-            Arg.Any<object>(),
-            default);
-    }
-
-    [Fact]
-    public async Task Handle_ValidTextAnomalyValidation_CallsReplyFlexAsync()
-    {
-        // Arrange
-        const string lossJson = """{"items":[{"name":"青江菜","is_new":false,"buy_price":100,"sell_price":150,"quantity":10,"unit":"箱"}]}""";
-        SetupChatClientReturns(lossJson);
-        _pricingService.GetHistoricalAvgPriceAsync("青江菜", Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(18m);
-        _validationService.Validate(100m, 150m, 18m).Returns(ValidationResult.Anomaly("與歷史均價落差 456%"));
-        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
-            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
-        
-        var command = CreateCommand("青江菜 100 賣 150 十箱");
-
-        // Act
-        await _handler.Handle(command, default);
-
-        // Assert
-        await _lineReplyService.Received(1).ReplyFlexAsync(
-            "reply-token-123",
-            Arg.Is<string>(alt => alt.Contains("1項異常")),
-            Arg.Any<object>(),
-            default);
-    }
-
-    [Fact]
-    public async Task Handle_MultipleItemsMixed_CallsReplyFlexAsync()
-    {
-        // Arrange
-        const string mixedJson = """{"items":[{"name":"初秋高麗菜","is_new":false,"buy_price":25,"sell_price":35,"quantity":50,"unit":"箱"},{"name":"青江菜","is_new":false,"buy_price":50,"sell_price":40,"quantity":10,"unit":"箱"}]}""";
-        SetupChatClientReturns(mixedJson);
-        
-        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(26m);
-        _pricingService.GetHistoricalAvgPriceAsync("青江菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(18m);
-        
-        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
-        _validationService.Validate(50m, 40m, 18m).Returns(ValidationResult.Anomaly("售價低於或等於進價"));
-        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
-            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
-        
-        var command = CreateCommand();
-
-        // Act
-        await _handler.Handle(command, default);
-
-        // Assert
-        await _lineReplyService.Received(1).ReplyFlexAsync(
-            "reply-token-123",
-            Arg.Is<string>(alt => alt.Contains("1項正常") && alt.Contains("1項異常")),
-            Arg.Any<object>(),
-            default);
-    }
-
-    [Fact]
-    public async Task Handle_FlexBuilderThrows_FallsBackToTextReply()
-    {
-        // Arrange
-        SetupChatClientReturns(ValidJson);
-        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(26m);
-        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
-        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
-            .Throws(new InvalidOperationException("Flex build error"));
-        
-        var command = CreateCommand();
-
-        // Act
-        await _handler.Handle(command, default);
-
-        // Assert — falls back to ReplyTextAsync with plain text format
-        await _lineReplyService.Received(1).ReplyTextAsync(
-            "reply-token-123",
-            Arg.Is<string>(text => text.Contains("🟢") && text.Contains("初秋高麗菜")),
             default);
     }
 
@@ -165,36 +71,20 @@ public sealed class ProcessTextMessageHandlerTests
     }
 
     [Fact]
-    public async Task Handle_EmptyReplyToken_DoesNotCallLineReplyService()
+    public async Task Handle_EmptyReplyToken_DoesNotCallAnything()
     {
-        SetupChatClientReturns(ValidJson);
         var command = CreateCommand(replyToken: "");
 
         await _handler.Handle(command, default);
 
-        await _lineReplyService.DidNotReceive().ReplyTextAsync(
-            Arg.Any<string>(),
+        await _chatClient.DidNotReceive().GetResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>());
+        await _validationReplyService.DidNotReceive().ProcessLlmResponseAndReplyAsync(
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>());
-        await _lineReplyService.DidNotReceive().ReplyFlexAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<object>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Handle_InvalidJson_RepliesParsingError()
-    {
-        SetupChatClientReturns("invalid json");
-        var command = CreateCommand();
-
-        await _handler.Handle(command, default);
-
-        await _lineReplyService.Received(1).ReplyTextAsync(
-            "reply-token-123",
-            "解析失敗，請重新輸入",
-            default);
     }
 
     [Fact]
@@ -216,45 +106,40 @@ public sealed class ProcessTextMessageHandlerTests
     }
 
     [Fact]
-    public async Task Handle_LineReplyFlexThrows_LogsWarning()
+    public async Task Handle_ChatClientReturnsNull_DelegatesEmptyToService()
     {
-        SetupChatClientReturns(ValidJson);
-        _pricingService.GetHistoricalAvgPriceAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(26m);
-        _validationService.Validate(Arg.Any<decimal>(), Arg.Any<decimal>(), Arg.Any<decimal?>()).Returns(ValidationResult.Ok());
-        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
-            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
-        
-        _lineReplyService.ReplyFlexAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<object>(),
+        _chatClient.GetResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("LINE API error"));
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, (string?)null)));
+        var command = CreateCommand();
+
+        await _handler.Handle(command, default);
+
+        await _validationReplyService.Received(1).ProcessLlmResponseAndReplyAsync(
+            "",
+            "reply-token-123",
+            default);
+    }
+
+    [Fact]
+    public async Task Handle_BusyReplyAlsoThrows_DoesNotThrow()
+    {
+        _chatClient.GetResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("API error"));
+        _lineReplyService.ReplyTextAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Reply also failed"));
         var command = CreateCommand();
 
         await _handler.Handle(command, default);
 
         // Should complete without throwing
-    }
-
-    [Fact]
-    public async Task Handle_MarkdownCodeFence_StripsFenceAndProcesses()
-    {
-        var jsonWithCodeFence = $"```json\n{ValidJson}\n```";
-        SetupChatClientReturns(jsonWithCodeFence);
-        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(26m);
-        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
-        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
-            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
-        
-        var command = CreateCommand();
-
-        await _handler.Handle(command, default);
-
-        await _lineReplyService.Received(1).ReplyFlexAsync(
-            "reply-token-123",
-            Arg.Any<string>(),
-            Arg.Any<object>(),
-            default);
     }
 }

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/ValidationReplyServiceTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/ValidationReplyServiceTests.cs
@@ -1,0 +1,163 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Application.Services;
+using VeggieAlly.Domain.Abstractions;
+using VeggieAlly.Domain.ValueObjects;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class ValidationReplyServiceTests
+{
+    private readonly ILineReplyService _lineReplyService = Substitute.For<ILineReplyService>();
+    private readonly IVegetablePricingService _pricingService = Substitute.For<IVegetablePricingService>();
+    private readonly IPriceValidationService _validationService = Substitute.For<IPriceValidationService>();
+    private readonly IFlexMessageBuilder _flexMessageBuilder = Substitute.For<IFlexMessageBuilder>();
+    private readonly ILogger<ValidationReplyService> _logger = Substitute.For<ILogger<ValidationReplyService>>();
+    private readonly ValidationReplyService _service;
+
+    private const string ValidJson = """{"items":[{"name":"初秋高麗菜","is_new":false,"buy_price":25,"sell_price":35,"quantity":50,"unit":"箱"}]}""";
+
+    public ValidationReplyServiceTests()
+    {
+        _service = new ValidationReplyService(_lineReplyService, _pricingService, _validationService, _flexMessageBuilder, _logger);
+    }
+
+    private void SetupOkValidation()
+    {
+        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(26m);
+        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
+        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
+            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_ValidJsonOk_CallsReplyFlexAsync()
+    {
+        SetupOkValidation();
+
+        await _service.ProcessLlmResponseAndReplyAsync(ValidJson, "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyFlexAsync(
+            "reply-token",
+            Arg.Is<string>(alt => alt.Contains("1項正常")),
+            Arg.Any<object>(),
+            default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_AnomalyValidation_CallsReplyFlexWithAnomaly()
+    {
+        const string lossJson = """{"items":[{"name":"青江菜","is_new":false,"buy_price":100,"sell_price":150,"quantity":10,"unit":"箱"}]}""";
+        _pricingService.GetHistoricalAvgPriceAsync("青江菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(18m);
+        _validationService.Validate(100m, 150m, 18m).Returns(ValidationResult.Anomaly("與歷史均價落差 456%"));
+        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
+            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
+
+        await _service.ProcessLlmResponseAndReplyAsync(lossJson, "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyFlexAsync(
+            "reply-token",
+            Arg.Is<string>(alt => alt.Contains("1項異常")),
+            Arg.Any<object>(),
+            default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_MixedItems_CallsReplyFlexWithMixed()
+    {
+        const string mixedJson = """{"items":[{"name":"初秋高麗菜","is_new":false,"buy_price":25,"sell_price":35,"quantity":50,"unit":"箱"},{"name":"青江菜","is_new":false,"buy_price":50,"sell_price":40,"quantity":10,"unit":"箱"}]}""";
+        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(26m);
+        _pricingService.GetHistoricalAvgPriceAsync("青江菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(18m);
+        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
+        _validationService.Validate(50m, 40m, 18m).Returns(ValidationResult.Anomaly("售價低於或等於進價"));
+        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
+            .Returns(new Dictionary<string, object> { ["type"] = "bubble" });
+
+        await _service.ProcessLlmResponseAndReplyAsync(mixedJson, "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyFlexAsync(
+            "reply-token",
+            Arg.Is<string>(alt => alt.Contains("1項正常") && alt.Contains("1項異常")),
+            Arg.Any<object>(),
+            default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_NullResponse_RepliesParsingError()
+    {
+        await _service.ProcessLlmResponseAndReplyAsync(null, "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync("reply-token", "解析失敗，請重新輸入", default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_EmptyResponse_RepliesParsingError()
+    {
+        await _service.ProcessLlmResponseAndReplyAsync("", "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync("reply-token", "解析失敗，請重新輸入", default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_InvalidJson_RepliesParsingError()
+    {
+        await _service.ProcessLlmResponseAndReplyAsync("not json", "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync("reply-token", "解析失敗，請重新輸入", default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_EmptyItems_RepliesParsingError()
+    {
+        await _service.ProcessLlmResponseAndReplyAsync("{\"items\":[]}", "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync("reply-token", "解析失敗，請重新輸入", default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_FlexBuilderThrows_FallsBackToText()
+    {
+        _pricingService.GetHistoricalAvgPriceAsync("初秋高麗菜", Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(26m);
+        _validationService.Validate(25m, 35m, 26m).Returns(ValidationResult.Ok());
+        _flexMessageBuilder.BuildBubble(Arg.Any<IReadOnlyList<ValidatedVegetableItem>>())
+            .Throws(new InvalidOperationException("Flex build error"));
+
+        await _service.ProcessLlmResponseAndReplyAsync(ValidJson, "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyTextAsync(
+            "reply-token",
+            Arg.Is<string>(text => text.Contains("🟢") && text.Contains("初秋高麗菜")),
+            default);
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_ReplyThrows_DoesNotThrow()
+    {
+        SetupOkValidation();
+        _lineReplyService.ReplyFlexAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("LINE API error"));
+
+        await _service.ProcessLlmResponseAndReplyAsync(ValidJson, "reply-token", default);
+
+        // Should complete without throwing
+    }
+
+    [Fact]
+    public async Task ProcessLlmResponse_MarkdownCodeFence_StripsAndProcesses()
+    {
+        var jsonWithFence = $"```json\n{ValidJson}\n```";
+        SetupOkValidation();
+
+        await _service.ProcessLlmResponseAndReplyAsync(jsonWithFence, "reply-token", default);
+
+        await _lineReplyService.Received(1).ReplyFlexAsync(
+            "reply-token",
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            default);
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/WebhookControllerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/WebhookControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.LineEvents.ProcessAudio;
 using VeggieAlly.Application.LineEvents.ProcessText;
 using VeggieAlly.Domain.Models.Line;
 using VeggieAlly.WebAPI.Controllers;
@@ -42,7 +43,7 @@ public sealed class WebhookControllerTests
     }
 
     [Fact]
-    public async Task Receive_TextMessage_DispatchesCommand()
+    public async Task Receive_TextMessage_DispatchesTextCommand()
     {
         var textEvent = new LineEvent(
             Type: "message",
@@ -60,7 +61,25 @@ public sealed class WebhookControllerTests
     }
 
     [Fact]
-    public async Task Receive_NonTextMessage_SkipsEvent()
+    public async Task Receive_AudioMessage_DispatchesAudioCommand()
+    {
+        var audioEvent = new LineEvent(
+            Type: "message",
+            ReplyToken: "reply-token-123",
+            Source: new LineEventSource("user", "U123"),
+            Message: new LineMessage("audio-msg-001", "audio", null));
+        var payload = new LineWebhookPayload([audioEvent]);
+
+        var result = await _controller.Receive(payload);
+
+        Assert.IsType<OkResult>(result);
+        await _mediator.Received(1).Send(
+            Arg.Is<ProcessAudioMessageCommand>(c => c.Event == audioEvent),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Receive_NonSupportedMessage_SkipsEvent()
     {
         var imageEvent = new LineEvent(
             Type: "message",
@@ -74,6 +93,9 @@ public sealed class WebhookControllerTests
         Assert.IsType<OkResult>(result);
         await _mediator.DidNotReceive().Send(
             Arg.Any<ProcessTextMessageCommand>(),
+            Arg.Any<CancellationToken>());
+        await _mediator.DidNotReceive().Send(
+            Arg.Any<ProcessAudioMessageCommand>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -96,7 +118,7 @@ public sealed class WebhookControllerTests
     }
 
     [Fact]
-    public async Task Receive_HandlerThrows_StillReturns200()
+    public async Task Receive_TextHandlerThrows_StillReturns200()
     {
         var textEvent = new LineEvent(
             Type: "message",
@@ -109,6 +131,26 @@ public sealed class WebhookControllerTests
             Arg.Any<ProcessTextMessageCommand>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Handler 爆了"));
+
+        var result = await _controller.Receive(payload);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task Receive_AudioHandlerThrows_StillReturns200()
+    {
+        var audioEvent = new LineEvent(
+            Type: "message",
+            ReplyToken: "reply-token-123",
+            Source: new LineEventSource("user", "U123"),
+            Message: new LineMessage("audio-msg-001", "audio", null));
+        var payload = new LineWebhookPayload([audioEvent]);
+
+        _mediator.Send(
+            Arg.Any<ProcessAudioMessageCommand>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Audio Handler 爆了"));
 
         var result = await _controller.Receive(payload);
 

--- a/docs/specs/P2-003-audio-stt-spec.md
+++ b/docs/specs/P2-003-audio-stt-spec.md
@@ -1,0 +1,204 @@
+# P2-003 語音訊息 (Audio Event) 處理與 STT 解析 — SA/SD 規格藍圖
+
+> **Issue**: #12  
+> **狀態**: Draft  
+> **前置**: P2-001 (價格驗證), P2-002 (Flex Message)
+
+---
+
+## 1. 目標
+
+使用者透過 LINE 傳送語音訊息給 Bot，Bot 透過 LINE Content API 下載 .m4a 音檔，
+經由 MEAI `IChatClient`（Gemini 多模態）一次完成 **STT + 結構化 JSON 解析**，
+解析結果進入 P2-001 驗證流程並以 P2-002 Flex Message 卡片回覆。
+
+---
+
+## 2. 架構設計
+
+### 2.1 資料流
+
+```
+LINE 使用者傳語音
+  → Webhook (type=message, message.type=audio)
+  → WebhookController 路由 → ProcessAudioMessageCommand
+  → ProcessAudioMessageHandler
+       1. ILineContentService.DownloadContentAsync(messageId) → byte[]
+       2. 建立 ChatMessage: System=VegetableParser, User=DataContent(audio/m4a)
+       3. IChatClient.GetResponseAsync → JSON string
+       4. IValidationReplyService.ValidateAndReplyAsync(json, replyToken)
+            → JSON 反序列化 → 價格查詢 → 驗證 → Flex Message → LINE Reply
+```
+
+### 2.2 新增元件
+
+| 層級 | 元件 | 職責 |
+|------|------|------|
+| Domain | `ILineContentService` | LINE Content API 抽象 |
+| Application | `IValidationReplyService` | 從 JSON 到 Flex 回覆的共用管線 |
+| Application | `ValidationReplyService` | 實作：反序列化 → 驗價 → Flex → Reply |
+| Application | `ProcessAudioMessageCommand` | MediatR Command |
+| Application | `ProcessAudioMessageHandler` | 音訊下載 → LLM → 驗證回覆 |
+| Infrastructure | `LineContentService` | HTTP 呼叫 LINE Content API |
+
+### 2.3 既有元件修改
+
+| 元件 | 修改 |
+|------|------|
+| `WebhookController` | 增加 `message.type == "audio"` 路由 |
+| `ProcessTextMessageHandler` | 抽出共用驗證管線至 `IValidationReplyService` |
+| `DependencyInjection` | 註冊 `ILineContentService`, `IValidationReplyService` |
+
+---
+
+## 3. 介面規格
+
+### 3.1 ILineContentService
+
+```csharp
+namespace VeggieAlly.Domain.Abstractions;
+
+public interface ILineContentService
+{
+    Task<byte[]> DownloadContentAsync(string messageId, CancellationToken ct = default);
+}
+```
+
+### 3.2 LineContentService
+
+```csharp
+// GET https://api-data.line.me/v2/bot/message/{messageId}/content
+// Authorization: Bearer {ChannelAccessToken}
+// Response: binary audio data
+```
+
+### 3.3 IValidationReplyService
+
+```csharp
+namespace VeggieAlly.Application.Common.Interfaces;
+
+public interface IValidationReplyService
+{
+    Task ValidateAndReplyAsync(string jsonContent, string replyToken, CancellationToken ct = default);
+}
+```
+
+### 3.4 ProcessAudioMessageCommand
+
+```csharp
+public sealed record ProcessAudioMessageCommand(LineEvent Event) : IRequest;
+```
+
+---
+
+## 4. MEAI 多模態呼叫規格
+
+```csharp
+// audio bytes from LINE Content API
+var audioContent = new DataContent(audioBytes, "audio/m4a");
+var messages = new ChatMessage[]
+{
+    new(ChatRole.System, SystemPrompts.VegetableParser),
+    new(ChatRole.User, [audioContent])
+};
+var response = await _chatClient.GetResponseAsync(messages, cancellationToken: ct);
+```
+
+重點：Gemini 多模態 API 在同一次呼叫中完成 STT + 結構化解析，不需兩次 LLM 呼叫。
+
+---
+
+## 5. WebhookController 路由更新
+
+```
+foreach (var lineEvent in payload.Events)
+{
+    if (lineEvent.Type != "message") continue;
+    if (string.IsNullOrWhiteSpace(lineEvent.ReplyToken)) continue;
+
+    switch (lineEvent.Message?.Type)
+    {
+        case "text":
+            await _mediator.Send(new ProcessTextMessageCommand(lineEvent));
+            break;
+        case "audio":
+            await _mediator.Send(new ProcessAudioMessageCommand(lineEvent));
+            break;
+        default:
+            _logger.LogDebug("跳過不支援的訊息類型: {Type}", lineEvent.Message?.Type);
+            break;
+    }
+}
+```
+
+---
+
+## 6. 錯誤處理策略
+
+| 場景 | 處理 |
+|------|------|
+| LINE Content API 下載失敗 | Reply "語音下載失敗，請重新錄音" |
+| 音檔為空 (0 bytes) | Reply "語音內容為空，請重新錄音" |
+| Gemini STT 解析失敗 (非 JSON) | Reply "語音解析失敗，請重新輸入" |
+| Gemini API 例外 | Reply "系統忙碌中，請稍後重試" |
+| 驗證管線失敗 | 同 ProcessTextMessageHandler 既有邏輯 |
+
+---
+
+## 7. 測試矩陣
+
+### 7.1 ProcessAudioMessageHandlerTests
+
+| # | 測試案例 | 預期 |
+|---|---------|------|
+| 1 | 正常音訊 → JSON → 驗證 OK | `ValidateAndReplyAsync` called |
+| 2 | MessageId 為空 | 不下載，Reply 錯誤訊息 |
+| 3 | ReplyToken 為空 | 不處理 |
+| 4 | Content 下載失敗 (exception) | Reply "語音下載失敗" |
+| 5 | Content 回傳空陣列 | Reply "語音內容為空" |
+| 6 | LLM 回傳非 JSON | `ValidateAndReplyAsync` 內處理 |
+| 7 | LLM 例外 | Reply "系統忙碌中" |
+
+### 7.2 ValidationReplyServiceTests
+
+| # | 測試案例 | 預期 |
+|---|---------|------|
+| 1 | 有效 JSON + 驗證 OK | ReplyFlexAsync called |
+| 2 | 有效 JSON + 異常 | ReplyFlexAsync with anomaly altText |
+| 3 | 無效 JSON | ReplyTextAsync "解析失敗" |
+| 4 | 空 items | ReplyTextAsync "解析失敗" |
+| 5 | Flex 建構失敗 | 降級純文字 |
+
+### 7.3 WebhookControllerTests (新增)
+
+| # | 測試案例 | 預期 |
+|---|---------|------|
+| 1 | Audio message event | Dispatches `ProcessAudioMessageCommand` |
+| 2 | Audio without ReplyToken | 跳過 |
+
+### 7.4 E2E 測試向量
+
+| # | 向量 | 預期 |
+|---|------|------|
+| E1 | HTTP POST audio event payload | HTTP 200 + handler 觸發 |
+
+---
+
+## 8. 檔案清單
+
+### 新增
+- `Domain/Abstractions/ILineContentService.cs`
+- `Application/Common/Interfaces/IValidationReplyService.cs`
+- `Application/Services/ValidationReplyService.cs`
+- `Application/LineEvents/ProcessAudio/ProcessAudioMessageCommand.cs`
+- `Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs`
+- `Infrastructure/Line/LineContentService.cs`
+- `tests/.../ProcessAudioMessageHandlerTests.cs`
+- `tests/.../ValidationReplyServiceTests.cs`
+
+### 修改
+- `WebAPI/Controllers/WebhookController.cs`
+- `Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs`
+- `Infrastructure/DependencyInjection.cs`
+- `tests/.../WebhookControllerTests.cs`
+- `tests/.../ProcessTextMessageHandlerTests.cs`


### PR DESCRIPTION
## 變更摘要

串接 LINE Content API 下載語音 .m4a，並打通 Gemini 多模態 Audio 解析能力。

### 新增
- `ILineContentService` + `LineContentService` — LINE Content API 下載語音
- `IValidationReplyService` + `ValidationReplyService` — 共用驗證回覆管線（從 ProcessTextMessageHandler 抽出）
- `ProcessAudioMessageCommand` + `ProcessAudioMessageHandler` — 語音訊息處理
- `ProcessAudioMessageHandlerTests` — 7 個測試
- `ValidationReplyServiceTests` — 10 個測試

### 修改
- `WebhookController` — 新增 audio 事件路由（switch 分派）
- `ProcessTextMessageHandler` — 使用 IValidationReplyService 簡化
- `DependencyInjection` — 註冊 ILineContentService、IValidationReplyService
- `WebhookControllerTests` — 新增 audio 路由測試（共 8 測試）
- `ProcessTextMessageHandlerTests` — 簡化為 6 測試（驗證邏輯移至 ValidationReplyServiceTests）

### 測試
- **85 通過 / 0 失敗**（從 70 增加到 85）
- E2E: 3 向量全部 HTTP 200，handler 正確觸發

Closes #12