### PR TITLE
feat(P3-002): 發布菜單與庫存扣減 — Issue #17

### DIFF
--- a/VeggieAlly/db/migrations/001_create_published_menus.sql
+++ b/VeggieAlly/db/migrations/001_create_published_menus.sql
@@ -1,0 +1,57 @@
+-- P3-002: 一鍵發布鎖定 + 今日菜單 API + 庫存扣除
+-- 建立已發布菜單相關資料表
+
+-- 已發布菜單主表
+CREATE TABLE IF NOT EXISTS published_menus (
+    id              VARCHAR(32)     PRIMARY KEY,           -- GUID "N" 格式
+    tenant_id       VARCHAR(64)     NOT NULL,              -- 租戶 ID
+    published_by    VARCHAR(64)     NOT NULL,              -- 發布者 LINE User ID
+    date            DATE            NOT NULL,              -- 菜單日期
+    published_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),-- 發布時間 (UTC)
+    
+    -- 確保每個租戶每天只能發布一次
+    CONSTRAINT uq_published_menus_tenant_date UNIQUE (tenant_id, date)
+);
+
+-- 索引
+CREATE INDEX IF NOT EXISTS idx_published_menus_tenant_date ON published_menus (tenant_id, date);
+CREATE INDEX IF NOT EXISTS idx_published_menus_published_at ON published_menus (published_at);
+
+-- 已發布菜單品項表
+CREATE TABLE IF NOT EXISTS published_menu_items (
+    id                  VARCHAR(32)     PRIMARY KEY,       -- GUID "N" 格式
+    menu_id             VARCHAR(32)     NOT NULL REFERENCES published_menus(id) ON DELETE CASCADE,
+    tenant_id           VARCHAR(64)     NOT NULL,          -- 冗余儲存租戶 ID，便於查詢優化
+    name                VARCHAR(128)    NOT NULL,          -- 品項名稱
+    is_new              BOOLEAN         NOT NULL DEFAULT FALSE, -- 是否新品
+    buy_price           DECIMAL(10,2)   NOT NULL,          -- 進貨價
+    sell_price          DECIMAL(10,2)   NOT NULL,          -- 售價
+    original_qty        INT             NOT NULL,          -- 原始數量
+    remaining_qty       INT             NOT NULL,          -- 剩餘庫存 
+    unit                VARCHAR(16)     NOT NULL,          -- 單位
+    historical_avg_price DECIMAL(10,2),                   -- 歷史平均價（可選）
+    
+    -- 確保庫存不會是負數
+    CONSTRAINT chk_remaining_qty CHECK (remaining_qty >= 0),
+    CONSTRAINT chk_original_qty CHECK (original_qty >= 0),
+    CONSTRAINT chk_prices CHECK (buy_price >= 0 AND sell_price >= 0)
+);
+
+-- 索引
+CREATE INDEX IF NOT EXISTS idx_published_menu_items_menu_id ON published_menu_items (menu_id);
+CREATE INDEX IF NOT EXISTS idx_published_menu_items_tenant ON published_menu_items (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_published_menu_items_name ON published_menu_items (name);
+
+-- 建立註解
+COMMENT ON TABLE published_menus IS '已發布菜單主表 - 每日每租戶一筆記錄';
+COMMENT ON TABLE published_menu_items IS '已發布菜單品項表 - 包含庫存管理';
+
+COMMENT ON COLUMN published_menus.id IS 'GUID "N" 格式唯一識別碼';
+COMMENT ON COLUMN published_menus.tenant_id IS '租戶識別碼，用於多租戶隔離';
+COMMENT ON COLUMN published_menus.published_by IS '發布者 LINE User ID';
+COMMENT ON COLUMN published_menus.date IS '菜單適用日期（以台灣時間為準）';
+COMMENT ON COLUMN published_menus.published_at IS 'UTC 發布時間戳';
+
+COMMENT ON COLUMN published_menu_items.remaining_qty IS '目前剩餘庫存，會因銷售而遞減';
+COMMENT ON COLUMN published_menu_items.original_qty IS '原始發布數量，不變';
+COMMENT ON COLUMN published_menu_items.tenant_id IS '冗余儲存，避免跨表JOIN查詢';

--- a/VeggieAlly/docker-compose.yml
+++ b/VeggieAlly/docker-compose.yml
@@ -5,6 +5,18 @@ services:
       - "6379:6379"
     restart: unless-stopped
 
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: veggie
+      POSTGRES_PASSWORD: veggie_dev
+      POSTGRES_DB: veggieally
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+
   veggie-ally:
     build:
       context: .
@@ -14,6 +26,7 @@ services:
       - "5001:8081"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__PostgreSQL=Host=postgres;Database=veggieally;Username=veggie;Password=veggie_dev
       - Line__ChannelSecret=${LINE_CHANNEL_SECRET}
       - Line__ChannelAccessToken=${LINE_CHANNEL_ACCESS_TOKEN}
       - Line__TenantId=default
@@ -23,4 +36,8 @@ services:
       - Gemini__ModelId=gemini-2.0-flash
     depends_on:
       - redis
+      - postgres
     restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IFlexMessageBuilder.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IFlexMessageBuilder.cs
@@ -1,5 +1,6 @@
 using VeggieAlly.Domain.ValueObjects;
 using VeggieAlly.Domain.Models.Draft;
+using VeggieAlly.Domain.Models.Menu;
 
 namespace VeggieAlly.Application.Common.Interfaces;
 
@@ -14,6 +15,13 @@ public interface IFlexMessageBuilder
     /// <summary>
     /// 根據草稿 Session 組裝 LINE Flex Message BubbleContainer（含 LIFF 修正按鈕）。
     /// 異常品項會包含修正按鈕，正常品項無按鈕。
+    /// 全部品項 Status == Ok 時，Footer 顯示 🚀 一鍵發布 Postback 按鈕。
     /// </summary>
     object BuildDraftBubble(DraftMenuSession session, string? liffBaseUrl);
+
+    /// <summary>
+    /// 根據已發布菜單組裝 LINE Flex Message BubbleContainer（發布確認卡片）。
+    /// 顯示 ✅ 菜單已發布確認訊息。
+    /// </summary>
+    object BuildPublishedBubble(PublishedMenu menu);
 }

--- a/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IPublishedMenuCache.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IPublishedMenuCache.cs
@@ -1,0 +1,29 @@
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Common.Interfaces;
+
+/// <summary>
+/// 已發布菜單 Redis 快取
+/// </summary>
+public interface IPublishedMenuCache
+{
+    /// <summary>
+    /// 從快取取得已發布菜單
+    /// </summary>
+    Task<PublishedMenu?> GetAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+
+    /// <summary>
+    /// 設定快取（write-through）
+    /// </summary>
+    Task SetAsync(PublishedMenu menu, CancellationToken ct = default);
+
+    /// <summary>
+    /// 移除快取
+    /// </summary>
+    Task RemoveAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+
+    /// <summary>
+    /// 檢查快取是否存在（用於防止重複發布）
+    /// </summary>
+    Task<bool> ExistsAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+}

--- a/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IPublishedMenuRepository.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Common/Interfaces/IPublishedMenuRepository.cs
@@ -1,0 +1,33 @@
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Common.Interfaces;
+
+/// <summary>
+/// 已發布菜單 Repository — Dapper 實作
+/// </summary>
+public interface IPublishedMenuRepository
+{
+    /// <summary>
+    /// 根據租戶 ID 和日期查詢已發布菜單
+    /// </summary>
+    Task<PublishedMenu?> GetByTenantAndDateAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+
+    /// <summary>
+    /// 插入已發布菜單（包含所有品項）
+    /// </summary>
+    Task InsertAsync(PublishedMenu menu, CancellationToken ct = default);
+
+    /// <summary>
+    /// 庫存扣除，使用樂觀鎖語意 — 在 remaining_qty >= amount 時才扣除
+    /// </summary>
+    /// <param name="tenantId">租戶 ID</param>
+    /// <param name="itemId">品項 ID</param>
+    /// <param name="amount">扣除數量</param>
+    /// <returns>影響的列數（為 0 表示庫存不足）</returns>
+    Task<int> DeductItemStockAsync(string tenantId, string itemId, int amount, CancellationToken ct = default);
+
+    /// <summary>
+    /// 刪除指定租戶的指定日期菜單
+    /// </summary>
+    Task DeleteByTenantAndDateAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+}

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/DeductInventory/DeductInventoryCommand.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/DeductInventory/DeductInventoryCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Menu.DeductInventory;
+
+/// <summary>
+/// 庫存扣除命令
+/// </summary>
+public sealed record DeductInventoryCommand(
+    string TenantId,
+    string ItemId,
+    int Amount) : IRequest<PublishedMenuItem>;

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/DeductInventory/DeductInventoryHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/DeductInventory/DeductInventoryHandler.cs
@@ -1,0 +1,59 @@
+using MediatR;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Menu.DeductInventory;
+
+/// <summary>
+/// 庫存扣除處理器 — 樂觀鎖 + write-through 快取
+/// </summary>
+public sealed class DeductInventoryHandler : IRequestHandler<DeductInventoryCommand, PublishedMenuItem>
+{
+    private readonly IPublishedMenuRepository _repository;
+    private readonly IPublishedMenuCache _cache;
+
+    public DeductInventoryHandler(IPublishedMenuRepository repository, IPublishedMenuCache cache)
+    {
+        _repository = repository;
+        _cache = cache;
+    }
+
+    public async Task<PublishedMenuItem> Handle(DeductInventoryCommand request, CancellationToken cancellationToken)
+    {
+        // 驗證參數
+        if (request.Amount <= 0)
+            throw new ArgumentException("扣除數量必須大於 0", nameof(request.Amount));
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        // 1. 庫存扣除（樂觀鎖）
+        var affected = await _repository.DeductItemStockAsync(
+            request.TenantId, 
+            request.ItemId, 
+            request.Amount, 
+            cancellationToken);
+
+        // 2. 如果 affected == 0，表示庫存不足
+        if (affected == 0)
+            throw new InsufficientStockException(request.ItemId);
+
+        // 3. 重新讀取完整菜單（避免部分更新造成不一致）
+        var updatedMenu = await _repository.GetByTenantAndDateAsync(request.TenantId, today, cancellationToken)
+            ?? throw new MenuNotPublishedException();
+
+        // 4. write-through 更新快取
+        try
+        {
+            await _cache.SetAsync(updatedMenu, cancellationToken);
+        }
+        catch
+        {
+            // 快取更新失敗，不影響主流程
+        }
+
+        // 5. 回傳更新後的品項
+        var updatedItem = updatedMenu.Items.First(i => i.Id == request.ItemId);
+        return updatedItem;
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/GetToday/GetTodayMenuHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/GetToday/GetTodayMenuHandler.cs
@@ -1,0 +1,55 @@
+using MediatR;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Menu.GetToday;
+
+/// <summary>
+/// 今日菜單查詢處理器 — 首先查詢 Redis，再查詢 DB，找到後回填快取
+/// </summary>
+public sealed class GetTodayMenuHandler : IRequestHandler<GetTodayMenuQuery, PublishedMenu?>
+{
+    private readonly IPublishedMenuCache _cache;
+    private readonly IPublishedMenuRepository _repository;
+
+    public GetTodayMenuHandler(IPublishedMenuCache cache, IPublishedMenuRepository repository)
+    {
+        _cache = cache;
+        _repository = repository;
+    }
+
+    public async Task<PublishedMenu?> Handle(GetTodayMenuQuery request, CancellationToken cancellationToken)
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        // 1. 首先查詢 Redis 快取
+        try
+        {
+            var cached = await _cache.GetAsync(request.TenantId, today, cancellationToken);
+            if (cached is not null)
+                return cached;
+        }
+        catch
+        {
+            // 快取失敗，直接查詢 DB
+        }
+
+        // 2. 查詢 DB
+        var menu = await _repository.GetByTenantAndDateAsync(request.TenantId, today, cancellationToken);
+        
+        // 3. 如果找到，回填快取
+        if (menu is not null)
+        {
+            try
+            {
+                await _cache.SetAsync(menu, cancellationToken);
+            }
+            catch
+            {
+                // 快取回填失敗，不影響結果
+            }
+        }
+
+        return menu;
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/GetToday/GetTodayMenuQuery.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/GetToday/GetTodayMenuQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Menu.GetToday;
+
+/// <summary>
+/// 今日菜單查詢
+/// </summary>
+public sealed record GetTodayMenuQuery(
+    string TenantId) : IRequest<PublishedMenu?>;

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/Unpublish/UnpublishMenuCommand.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/Unpublish/UnpublishMenuCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace VeggieAlly.Application.Menu.Unpublish;
+
+/// <summary>
+/// 撤回發布命令 — MVP 階段回傳 501 Not Implemented
+/// </summary>
+public sealed record UnpublishMenuCommand(
+    string TenantId) : IRequest;

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/Unpublish/UnpublishMenuHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/Unpublish/UnpublishMenuHandler.cs
@@ -1,0 +1,15 @@
+using MediatR;
+
+namespace VeggieAlly.Application.Menu.Unpublish;
+
+/// <summary>
+/// 撤回發布處理器 — MVP 命令回傳 NotImplementedException
+/// </summary>
+public sealed class UnpublishMenuHandler : IRequestHandler<UnpublishMenuCommand>
+{
+    public Task Handle(UnpublishMenuCommand request, CancellationToken cancellationToken)
+    {
+        // MVP 階段不實作撤回功能，出於安全和資料一致性考量
+        throw new NotImplementedException("撤回功能将在後續版本實作");
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
@@ -1,6 +1,7 @@
 using VeggieAlly.Application.Common.Interfaces;
 using VeggieAlly.Domain.ValueObjects;
 using VeggieAlly.Domain.Models.Draft;
+using VeggieAlly.Domain.Models.Menu;
 
 namespace VeggieAlly.Application.Services;
 
@@ -123,9 +124,42 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
             }
         }
 
-        var footerText = string.IsNullOrWhiteSpace(liffBaseUrl)
-            ? "💡 如需修正，請重新傳送語音或文字"
-            : "💡 點擊修正按鈕或重新傳送語音修正";
+        // Footer 根據情況顯示不同內容
+        var footerContents = new List<object>();
+        
+        if (anomalyItems.Count == 0 && okItems.Count > 0)
+        {
+            // 全部品項都 Ok，顯示發布按鈕
+            footerContents.Add(new Dictionary<string, object>
+            {
+                ["type"] = "button",
+                ["height"] = "sm",
+                ["style"] = "primary",
+                ["color"] = "#1DB446",
+                ["action"] = new Dictionary<string, object>
+                {
+                    ["type"] = "postback",
+                    ["label"] = "🚀 一鍵發布",
+                    ["data"] = "action=publish"
+                }
+            });
+        }
+        else
+        {
+            // 有異常品項，顯示修正提示
+            var footerText = string.IsNullOrWhiteSpace(liffBaseUrl)
+                ? "💡 如需修正，請重新傳送語音或文字"
+                : "💡 點擊修正按鈕或重新傳送語音修正";
+                
+            footerContents.Add(new Dictionary<string, object>
+            {
+                ["type"] = "text",
+                ["text"] = footerText,
+                ["size"] = "xs",
+                ["color"] = "#AAAAAA",
+                ["align"] = "center"
+            });
+        }
 
         var bubble = new Dictionary<string, object>
         {
@@ -157,17 +191,7 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
             {
                 ["type"] = "box",
                 ["layout"] = "vertical",
-                ["contents"] = new List<object>
-                {
-                    new Dictionary<string, object>
-                    {
-                        ["type"] = "text",
-                        ["text"] = footerText,
-                        ["size"] = "xs",
-                        ["color"] = "#AAAAAA",
-                        ["align"] = "center"
-                    }
-                }
+                ["contents"] = footerContents
             }
         };
 
@@ -346,6 +370,155 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
             ["layout"] = "vertical",
             ["margin"] = "sm",
             ["contents"] = contents
+        };
+    }
+
+    public object BuildPublishedBubble(PublishedMenu menu)
+    {
+        if (menu?.Items is null || menu.Items.Count == 0)
+            throw new ArgumentException("已發布菜單不得為空", nameof(menu));
+
+        var bodyContents = new List<object>
+        {
+            // 成功訊息
+            new Dictionary<string, object>
+            {
+                ["type"] = "box",
+                ["layout"] = "horizontal",
+                ["contents"] = new List<object>
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["type"] = "text",
+                        ["text"] = "✅",
+                        ["size"] = "xxl",
+                        ["flex"] = 1
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["type"] = "box",
+                        ["layout"] = "vertical",
+                        ["flex"] = 4,
+                        ["contents"] = new List<object>
+                        {
+                            new Dictionary<string, object>
+                            {
+                                ["type"] = "text",
+                                ["text"] = "菜單發布成功！",
+                                ["weight"] = "bold",
+                                ["size"] = "lg",
+                                ["color"] = "#1DB446"
+                            },
+                            new Dictionary<string, object>
+                            {
+                                ["type"] = "text",
+                                ["text"] = $"共 {menu.Items.Count} 項商品",
+                                ["size"] = "sm",
+                                ["color"] = "#666666",
+                                ["margin"] = "xs"
+                            }
+                        }
+                    }
+                }
+            },
+            CreateSeparator("lg")
+        };
+
+        // 商品清單（限制顯示前5項）
+        var displayItems = menu.Items.Take(5);
+        foreach (var item in displayItems)
+        {
+            bodyContents.Add(CreatePublishedItemRow(item));
+        }
+
+        // 如果商品超過5項，顯示省略提示
+        if (menu.Items.Count > 5)
+        {
+            bodyContents.Add(new Dictionary<string, object>
+            {
+                ["type"] = "text",
+                ["text"] = $"... 等共 {menu.Items.Count} 項商品",
+                ["size"] = "xs",
+                ["color"] = "#AAAAAA",
+                ["align"] = "center",
+                ["margin"] = "md"
+            });
+        }
+
+        var bubble = new Dictionary<string, object>
+        {
+            ["type"] = "bubble",
+            ["header"] = new Dictionary<string, object>
+            {
+                ["type"] = "box",
+                ["layout"] = "vertical",
+                ["contents"] = new List<object>
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["type"] = "text",
+                        ["text"] = "🎉 發布完成",
+                        ["weight"] = "bold",
+                        ["size"] = "lg",
+                        ["color"] = "#333333"
+                    }
+                }
+            },
+            ["body"] = new Dictionary<string, object>
+            {
+                ["type"] = "box",
+                ["layout"] = "vertical",
+                ["spacing"] = "sm",
+                ["contents"] = bodyContents
+            },
+            ["footer"] = new Dictionary<string, object>
+            {
+                ["type"] = "box",
+                ["layout"] = "vertical",
+                ["contents"] = new List<object>
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["type"] = "text",
+                        ["text"] = "顧客現在可以透過 LIFF 查看今日菜單",
+                        ["size"] = "xs",
+                        ["color"] = "#AAAAAA",
+                        ["align"] = "center"
+                    }
+                }
+            }
+        };
+
+        return bubble;
+    }
+
+    private static Dictionary<string, object> CreatePublishedItemRow(PublishedMenuItem item)
+    {
+        return new Dictionary<string, object>
+        {
+            ["type"] = "box",
+            ["layout"] = "horizontal",
+            ["margin"] = "sm",
+            ["contents"] = new List<object>
+            {
+                new Dictionary<string, object>
+                {
+                    ["type"] = "text",
+                    ["text"] = item.Name,
+                    ["size"] = "sm",
+                    ["color"] = "#333333",
+                    ["flex"] = 3
+                },
+                new Dictionary<string, object>
+                {
+                    ["type"] = "text",
+                    ["text"] = $"${item.SellPrice} x{item.RemainingQty}{item.Unit}",
+                    ["size"] = "sm",
+                    ["color"] = "#666666",
+                    ["align"] = "end",
+                    ["flex"] = 2
+                }
+            }
         };
     }
 }

--- a/VeggieAlly/src/VeggieAlly.Domain/Exceptions/InsufficientStockException.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Exceptions/InsufficientStockException.cs
@@ -1,0 +1,15 @@
+namespace VeggieAlly.Domain.Exceptions;
+
+/// <summary>
+/// 庫存不足異常
+/// </summary>
+public sealed class InsufficientStockException : Exception
+{
+    public string ItemId { get; }
+    
+    public InsufficientStockException(string itemId)
+        : base($"庫存不足: {itemId}")
+    {
+        ItemId = itemId;
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Domain/Exceptions/MenuAlreadyPublishedException.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Exceptions/MenuAlreadyPublishedException.cs
@@ -1,0 +1,12 @@
+namespace VeggieAlly.Domain.Exceptions;
+
+/// <summary>
+/// 菜單已發布異常
+/// </summary>
+public sealed class MenuAlreadyPublishedException : Exception
+{
+    public MenuAlreadyPublishedException()
+        : base("今日菜單已發布")
+    {
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Domain/Exceptions/MenuNotPublishedException.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Exceptions/MenuNotPublishedException.cs
@@ -1,0 +1,12 @@
+namespace VeggieAlly.Domain.Exceptions;
+
+/// <summary>
+/// 尚未發布菜單異常
+/// </summary>
+public sealed class MenuNotPublishedException : Exception
+{
+    public MenuNotPublishedException()
+        : base("尚未發布菜單")
+    {
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Domain/Models/Line/LineEvent.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Models/Line/LineEvent.cs
@@ -1,7 +1,11 @@
 namespace VeggieAlly.Domain.Models.Line;
 
+/// <summary>
+/// LINE 事件 — 支援 message 和 postback 事件
+/// </summary>
 public sealed record LineEvent(
     string Type,
     string? ReplyToken,
     LineEventSource Source,
-    LineMessage? Message);
+    LineMessage? Message,
+    LinePostback? Postback = null);

--- a/VeggieAlly/src/VeggieAlly.Domain/Models/Line/LinePostback.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Models/Line/LinePostback.cs
@@ -1,0 +1,7 @@
+namespace VeggieAlly.Domain.Models.Line;
+
+/// <summary>
+/// LINE Postback 事件數據
+/// </summary>
+public sealed record LinePostback(
+    string Data);

--- a/VeggieAlly/src/VeggieAlly.Domain/Models/Menu/PublishedMenu.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Models/Menu/PublishedMenu.cs
@@ -1,0 +1,14 @@
+namespace VeggieAlly.Domain.Models.Menu;
+
+/// <summary>
+/// 已發布菜單 — 每日每租戶一筆
+/// </summary>
+public sealed class PublishedMenu
+{
+    public required string Id { get; init; }              // GUID "N" 格式
+    public required string TenantId { get; init; }
+    public required string PublishedByUserId { get; init; }
+    public required DateOnly Date { get; init; }
+    public required List<PublishedMenuItem> Items { get; init; }
+    public required DateTimeOffset PublishedAt { get; init; }
+}

--- a/VeggieAlly/src/VeggieAlly.Domain/Models/Menu/PublishedMenuItem.cs
+++ b/VeggieAlly/src/VeggieAlly.Domain/Models/Menu/PublishedMenuItem.cs
@@ -1,0 +1,18 @@
+namespace VeggieAlly.Domain.Models.Menu;
+
+/// <summary>
+/// 已發布菜單品項 — 包含庫存計數
+/// </summary>
+public sealed class PublishedMenuItem
+{
+    public required string Id { get; init; }              // GUID "N" 格式
+    public required string MenuId { get; init; }
+    public required string Name { get; init; }
+    public bool IsNew { get; init; }
+    public decimal BuyPrice { get; init; }
+    public decimal SellPrice { get; init; }
+    public int OriginalQty { get; init; }
+    public int RemainingQty { get; set; }
+    public required string Unit { get; init; }
+    public decimal? HistoricalAvgPrice { get; init; }
+}

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Cache/NoOpPublishedMenuCache.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Cache/NoOpPublishedMenuCache.cs
@@ -1,0 +1,22 @@
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Infrastructure.Cache;
+
+/// <summary>
+/// Redis 不可用時的 NoOp 實作，所有操作皆 miss/no-op
+/// </summary>
+public sealed class NoOpPublishedMenuCache : IPublishedMenuCache
+{
+    public Task<PublishedMenu?> GetAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+        => Task.FromResult<PublishedMenu?>(null);
+
+    public Task SetAsync(PublishedMenu menu, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task RemoveAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task<bool> ExistsAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+        => Task.FromResult(false);
+}

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Cache/PublishedMenuCache.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Cache/PublishedMenuCache.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using StackExchange.Redis;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Infrastructure.Cache;
+
+/// <summary>
+/// 已發布菜單 Redis 快取實作
+/// </summary>
+public sealed class PublishedMenuCache : IPublishedMenuCache
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly IDatabase _database;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public PublishedMenuCache(IConnectionMultiplexer redis)
+    {
+        _redis = redis;
+        _database = redis.GetDatabase();
+        
+        // 使用 snake_case 命名策略
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true
+        };
+    }
+
+    public async Task<PublishedMenu?> GetAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+    {
+        var key = GetCacheKey(tenantId, date);
+        var json = await _database.StringGetAsync(key);
+        
+        if (!json.HasValue)
+            return null;
+
+        return JsonSerializer.Deserialize<PublishedMenu>(json.ToString(), _jsonOptions);
+    }
+
+    public async Task SetAsync(PublishedMenu menu, CancellationToken ct = default)
+    {
+        var key = GetCacheKey(menu.TenantId, menu.Date);
+        var json = JsonSerializer.Serialize(menu, _jsonOptions);
+        var ttl = CalculateTtlUntilEndOfDay();
+
+        await _database.StringSetAsync(key, json, ttl);
+    }
+
+    public async Task RemoveAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+    {
+        var key = GetCacheKey(tenantId, date);
+        await _database.KeyDeleteAsync(key);
+    }
+
+    public async Task<bool> ExistsAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+    {
+        var key = GetCacheKey(tenantId, date);
+        return await _database.KeyExistsAsync(key);
+    }
+
+    private static string GetCacheKey(string tenantId, DateOnly date)
+    {
+        return $"{tenantId}:menu:published:{date:yyyy-MM-dd}";
+    }
+
+    /// <summary>
+    /// 計算至當日 23:59:59 (台灣時間 UTC+8) 的剩餘秒數
+    /// </summary>
+    private static TimeSpan CalculateTtlUntilEndOfDay()
+    {
+        // 获取台灣時間的現在時間
+        var taiwanTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Taipei");
+        var nowInTaiwan = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, taiwanTimeZone);
+        
+        // 計算當日 23:59:59 的時間
+        var endOfDay = nowInTaiwan.Date.AddDays(1).AddSeconds(-1);
+        
+        // 返回剩餘時間
+        var timeSpan = endOfDay - nowInTaiwan;
+        
+        // 確保最少有 1 分鐘的 TTL
+        return timeSpan.TotalSeconds > 60 ? timeSpan : TimeSpan.FromMinutes(1);
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/DependencyInjection.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/DependencyInjection.cs
@@ -1,13 +1,16 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.AI;
+using Npgsql;
 using OpenAI;
 using StackExchange.Redis;
 using VeggieAlly.Application.Common.Interfaces;
 using VeggieAlly.Application.Services;
 using VeggieAlly.Domain.Abstractions;
 using VeggieAlly.Infrastructure.AI;
+using VeggieAlly.Infrastructure.Cache;
 using VeggieAlly.Infrastructure.Line;
+using VeggieAlly.Infrastructure.Persistence;
 using VeggieAlly.Infrastructure.Services;
 using VeggieAlly.Infrastructure.Storage;
 
@@ -98,6 +101,28 @@ public static class DependencyInjection
 
         // ── Validation Reply Pipeline ──
         services.AddScoped<IValidationReplyService, ValidationReplyService>();
+
+        // ── PostgreSQL + Published Menu Services ──
+        var pgConnectionString = configuration.GetConnectionString("PostgreSQL");
+        if (!string.IsNullOrWhiteSpace(pgConnectionString))
+        {
+            var dataSourceBuilder = new NpgsqlDataSourceBuilder(pgConnectionString);
+            var dataSource = dataSourceBuilder.Build();
+            services.AddSingleton(dataSource);
+            
+            // Repository 服務
+            services.AddScoped<IPublishedMenuRepository, PublishedMenuRepository>();
+            
+            // Cache 服務
+            if (!string.IsNullOrWhiteSpace(redisConnectionString))
+            {
+                services.AddScoped<IPublishedMenuCache, PublishedMenuCache>();
+            }
+            else
+            {
+                services.AddScoped<IPublishedMenuCache, NoOpPublishedMenuCache>();
+            }
+        }
 
         return services;
     }

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using Dapper;
+using Npgsql;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Infrastructure.Persistence;
+
+/// <summary>
+/// 已發布菜單 Repository — Dapper + PostgreSQL 實作
+/// </summary>
+public sealed class PublishedMenuRepository : IPublishedMenuRepository
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public PublishedMenuRepository(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<PublishedMenu?> GetByTenantAndDateAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+
+        // 查詢菜單基本資訊
+        var menuSql = """
+            SELECT id, tenant_id, published_by, date, published_at 
+            FROM published_menus 
+            WHERE tenant_id = @TenantId AND date = @Date
+            """;
+
+        var menu = await connection.QueryFirstOrDefaultAsync(menuSql, new { TenantId = tenantId, Date = date });
+        if (menu is null)
+            return null;
+
+        // 查詢菜單品項
+        var itemsSql = """
+            SELECT id, menu_id, name, is_new, buy_price, sell_price, 
+                   original_qty, remaining_qty, unit, historical_avg_price
+            FROM published_menu_items 
+            WHERE menu_id = @MenuId AND tenant_id = @TenantId
+            ORDER BY name
+            """;
+
+        var items = await connection.QueryAsync(itemsSql, new { MenuId = menu.id, TenantId = tenantId });
+
+        return new PublishedMenu
+        {
+            Id = menu.id,
+            TenantId = menu.tenant_id,
+            PublishedByUserId = menu.published_by,
+            Date = menu.date,
+            PublishedAt = menu.published_at,
+            Items = items.Select(item => new PublishedMenuItem
+            {
+                Id = item.id,
+                MenuId = item.menu_id,
+                Name = item.name,
+                IsNew = item.is_new,
+                BuyPrice = item.buy_price,
+                SellPrice = item.sell_price,
+                OriginalQty = item.original_qty,
+                RemainingQty = item.remaining_qty,
+                Unit = item.unit,
+                HistoricalAvgPrice = item.historical_avg_price
+            }).ToList()
+        };
+    }
+
+    public async Task InsertAsync(PublishedMenu menu, CancellationToken ct = default)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var transaction = await connection.BeginTransactionAsync(ct);
+
+        try
+        {
+            // 插入菜單基本資訊
+            var menuSql = """
+                INSERT INTO published_menus (id, tenant_id, published_by, date, published_at)
+                VALUES (@Id, @TenantId, @PublishedByUserId, @Date, @PublishedAt)
+                """;
+
+            await connection.ExecuteAsync(menuSql, menu, transaction);
+
+            // 插入菜單品項
+            var itemSql = """
+                INSERT INTO published_menu_items (
+                    id, menu_id, tenant_id, name, is_new, buy_price, sell_price, 
+                    original_qty, remaining_qty, unit, historical_avg_price
+                )
+                VALUES (
+                    @Id, @MenuId, @TenantId, @Name, @IsNew, @BuyPrice, @SellPrice, 
+                    @OriginalQty, @RemainingQty, @Unit, @HistoricalAvgPrice
+                )
+                """;
+
+            foreach (var item in menu.Items)
+            {
+                await connection.ExecuteAsync(itemSql, new
+                {
+                    Id = item.Id,
+                    MenuId = item.MenuId,
+                    TenantId = menu.TenantId, // 為安全考量，使用菜單的 TenantId
+                    Name = item.Name,
+                    IsNew = item.IsNew,
+                    BuyPrice = item.BuyPrice,
+                    SellPrice = item.SellPrice,
+                    OriginalQty = item.OriginalQty,
+                    RemainingQty = item.RemainingQty,
+                    Unit = item.Unit,
+                    HistoricalAvgPrice = item.HistoricalAvgPrice
+                }, transaction);
+            }
+
+            await transaction.CommitAsync(ct);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct);
+            throw;
+        }
+    }
+
+    public async Task<int> DeductItemStockAsync(string tenantId, string itemId, int amount, CancellationToken ct = default)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+
+        // 樂觀鎖語意：只有當 remaining_qty >= amount 時才更新
+        var sql = """
+            UPDATE published_menu_items
+            SET remaining_qty = remaining_qty - @Amount
+            WHERE id = @ItemId AND tenant_id = @TenantId AND remaining_qty >= @Amount
+            """;
+
+        var affected = await connection.ExecuteAsync(sql, new 
+        { 
+            ItemId = itemId, 
+            TenantId = tenantId, 
+            Amount = amount 
+        });
+
+        return affected;
+    }
+
+    public async Task DeleteByTenantAndDateAsync(string tenantId, DateOnly date, CancellationToken ct = default)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+
+        // CASCADE 將自動刪除關聯的 published_menu_items
+        var sql = """
+            DELETE FROM published_menus 
+            WHERE tenant_id = @TenantId AND date = @Date
+            """;
+
+        await connection.ExecuteAsync(sql, new { TenantId = tenantId, Date = date });
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/VeggieAlly.Infrastructure.csproj
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/VeggieAlly.Infrastructure.csproj
@@ -5,12 +5,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.4.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
     <PackageReference Include="Mscc.GenerativeAI" Version="3.1.0" />
     <PackageReference Include="Mscc.GenerativeAI.Microsoft" Version="3.1.0" />
+    <PackageReference Include="Npgsql" Version="8.0.5" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
   </ItemGroup>
 

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/InventoryController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/InventoryController.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using VeggieAlly.Application.Menu.DeductInventory;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.WebAPI.Filters;
+
+namespace VeggieAlly.WebAPI.Controllers;
+
+[ApiController]
+[Route("api/menu")]
+public sealed class InventoryController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<InventoryController> _logger;
+
+    public InventoryController(IMediator mediator, ILogger<InventoryController> logger)
+    {
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// 庫存扣除
+    /// </summary>
+    [LiffAuth]
+    [HttpPatch("inventory")]
+    public async Task<IActionResult> DeductInventory(
+        [FromHeader(Name = "X-Tenant-Id")] string? tenantId,
+        [FromBody] DeductInventoryRequest request,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest(new { error = new { code = "MISSING_TENANT", message = "Missing tenant ID" } });
+
+        if (!ModelState.IsValid)
+        {
+            var errors = ModelState
+                .SelectMany(x => x.Value!.Errors)
+                .Select(x => x.ErrorMessage)
+                .ToArray();
+            return BadRequest(new { error = new { code = "VALIDATION_FAILED", message = string.Join("; ", errors) } });
+        }
+
+        try
+        {
+            var command = new DeductInventoryCommand(tenantId, request.ItemId, request.Amount);
+            var updatedItem = await _mediator.Send(command, ct);
+
+            _logger.LogInformation("Inventory deducted for item {ItemId} in tenant {TenantId}, amount: {Amount}", 
+                request.ItemId, tenantId, request.Amount);
+
+            return Ok(new
+            {
+                id = updatedItem.Id,
+                name = updatedItem.Name,
+                remaining_qty = updatedItem.RemainingQty,
+                unit = updatedItem.Unit
+            });
+        }
+        catch (InsufficientStockException ex)
+        {
+            return Conflict(new { error = new { code = "INSUFFICIENT_STOCK", message = ex.Message } });
+        }
+        catch (MenuNotPublishedException)
+        {
+            return NotFound(new { error = new { code = "MENU_NOT_FOUND", message = "今日尚未發布菜單" } });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = new { code = "INVALID_ARGUMENT", message = ex.Message } });
+        }
+    }
+}
+
+/// <summary>
+/// 庫存扣除請求 DTO
+/// </summary>
+public sealed record DeductInventoryRequest
+{
+    [Required(ErrorMessage = "Item ID is required")]
+    [JsonPropertyName("item_id")]
+    public required string ItemId { get; init; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Amount must be greater than 0")]
+    [JsonPropertyName("amount")]
+    public required int Amount { get; init; }
+}

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/MenuController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/MenuController.cs
@@ -1,0 +1,134 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using VeggieAlly.Application.Menu.GetToday;
+using VeggieAlly.Application.Menu.Publish;
+using VeggieAlly.Application.Menu.Unpublish;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.WebAPI.Filters;
+
+namespace VeggieAlly.WebAPI.Controllers;
+
+[ApiController]
+[Route("api/menu")]
+public sealed class MenuController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<MenuController> _logger;
+
+    public MenuController(IMediator mediator, ILogger<MenuController> logger)
+    {
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// 發布今日菜單
+    /// </summary>
+    [LiffAuth]
+    [HttpPost("publish")]
+    public async Task<IActionResult> PublishMenu(
+        [FromHeader(Name = "X-Tenant-Id")] string? tenantId,
+        [FromHeader(Name = "X-User-Id")] string? userId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest(new { error = new { code = "MISSING_TENANT", message = "Missing tenant ID" } });
+
+        if (string.IsNullOrWhiteSpace(userId))
+            return BadRequest(new { error = new { code = "MISSING_USER", message = "Missing user ID" } });
+
+        try
+        {
+            var command = new PublishMenuCommand(tenantId, userId);
+            var result = await _mediator.Send(command, ct);
+
+            _logger.LogInformation("Menu published successfully for tenant {TenantId} by user {UserId}", 
+                tenantId, userId);
+
+            return CreatedAtAction(nameof(GetTodayMenu), new { tenant_id = tenantId }, 
+                new
+                {
+                    id = result.Id,
+                    tenant_id = result.TenantId,
+                    date = result.Date.ToString("yyyy-MM-dd"),
+                    published_at = result.PublishedAt,
+                    items_count = result.Items.Count
+                });
+        }
+        catch (MenuAlreadyPublishedException)
+        {
+            return Conflict(new { error = new { code = "ALREADY_PUBLISHED", message = "今日菜單已發布" } });
+        }
+        catch (MenuNotPublishedException)
+        {
+            return NotFound(new { error = new { code = "NO_DRAFT", message = "尚未建立草稿菜單" } });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = new { code = "INVALID_OPERATION", message = ex.Message } });
+        }
+    }
+
+    /// <summary>
+    /// 撤回發布 (MVP: 回傳 501)
+    /// </summary>
+    [LiffAuth]
+    [HttpDelete("publish")]
+    public async Task<IActionResult> UnpublishMenu(
+        [FromHeader(Name = "X-Tenant-Id")] string? tenantId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest(new { error = new { code = "MISSING_TENANT", message = "Missing tenant ID" } });
+
+        try
+        {
+            var command = new UnpublishMenuCommand(tenantId);
+            await _mediator.Send(command, ct);
+            return NoContent();
+        }
+        catch (NotImplementedException ex)
+        {
+            return StatusCode(501, new { error = new { code = "NOT_IMPLEMENTED", message = ex.Message } });
+        }
+    }
+
+    /// <summary>
+    /// 查詢今日已發布菜單
+    /// </summary>
+    [LiffAuth]
+    [HttpGet("today")]
+    public async Task<IActionResult> GetTodayMenu(
+        [FromQuery(Name = "tenant_id")] string? tenantId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest(new { error = new { code = "MISSING_TENANT", message = "Missing tenant_id parameter" } });
+
+        var query = new GetTodayMenuQuery(tenantId);
+        var menu = await _mediator.Send(query, ct);
+
+        if (menu is null)
+            return NotFound(new { error = new { code = "MENU_NOT_FOUND", message = "今日尚未發布菜單" } });
+
+        _logger.LogInformation("Today menu retrieved for tenant {TenantId}", tenantId);
+
+        return Ok(new
+        {
+            id = menu.Id,
+            tenant_id = menu.TenantId,
+            date = menu.Date.ToString("yyyy-MM-dd"),
+            published_at = menu.PublishedAt,
+            items = menu.Items.Select(item => new
+            {
+                id = item.Id,
+                name = item.Name,
+                is_new = item.IsNew,
+                sell_price = item.SellPrice,
+                original_qty = item.OriginalQty,
+                remaining_qty = item.RemainingQty,
+                unit = item.Unit
+            })
+        });
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/WebhookController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/WebhookController.cs
@@ -1,8 +1,11 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using VeggieAlly.Application.Common.Interfaces;
 using VeggieAlly.Application.LineEvents.ProcessAudio;
 using VeggieAlly.Application.LineEvents.ProcessText;
+using VeggieAlly.Application.Menu.Publish;
 using VeggieAlly.Domain.Models.Line;
+using VeggieAlly.Domain.Exceptions;
 using VeggieAlly.WebAPI.Filters;
 
 namespace VeggieAlly.WebAPI.Controllers;
@@ -12,11 +15,13 @@ namespace VeggieAlly.WebAPI.Controllers;
 public sealed class WebhookController : ControllerBase
 {
     private readonly IMediator _mediator;
+    private readonly ITenantConfigService _tenantConfigService;
     private readonly ILogger<WebhookController> _logger;
 
-    public WebhookController(IMediator mediator, ILogger<WebhookController> logger)
+    public WebhookController(IMediator mediator, ITenantConfigService tenantConfigService, ILogger<WebhookController> logger)
     {
         _mediator = mediator;
+        _tenantConfigService = tenantConfigService;
         _logger = logger;
     }
 
@@ -32,12 +37,6 @@ public sealed class WebhookController : ControllerBase
 
         foreach (var lineEvent in payload.Events)
         {
-            if (lineEvent.Type != "message")
-            {
-                _logger.LogDebug("跳過非 message 事件: Type={EventType}", lineEvent.Type);
-                continue;
-            }
-
             // 跳過沒有 ReplyToken 的事件（如 Webhook 驗證事件）
             if (string.IsNullOrWhiteSpace(lineEvent.ReplyToken))
             {
@@ -47,29 +46,118 @@ public sealed class WebhookController : ControllerBase
 
             try
             {
-                switch (lineEvent.Message?.Type)
+                switch (lineEvent.Type)
                 {
-                    case "text":
-                        await _mediator.Send(new ProcessTextMessageCommand(lineEvent));
-                        _logger.LogInformation("成功處理文字訊息事件");
+                    case "message":
+                        await HandleMessageEvent(lineEvent);
                         break;
-                    case "audio":
-                        await _mediator.Send(new ProcessAudioMessageCommand(lineEvent));
-                        _logger.LogInformation("成功處理語音訊息事件");
+                    case "postback":
+                        await HandlePostbackEvent(lineEvent);
                         break;
                     default:
-                        _logger.LogDebug("跳過不支援的訊息類型: {MessageType}", lineEvent.Message?.Type);
+                        _logger.LogDebug("跳過不支援的事件類型: Type={EventType}", lineEvent.Type);
                         break;
                 }
             }
             catch (Exception ex)
             {
                 // 不向 LINE Platform 回傳錯誤，避免重複投遞
-                _logger.LogError(ex, "處理訊息事件時發生例外，但不影響回傳狀態");
+                _logger.LogError(ex, "處理事件時發生例外，但不影響回傳狀態: EventType={EventType}", lineEvent.Type);
             }
         }
 
         // 永遠回傳 200 OK
         return Ok();
+    }
+
+    private async Task HandleMessageEvent(LineEvent lineEvent)
+    {
+        switch (lineEvent.Message?.Type)
+        {
+            case "text":
+                await _mediator.Send(new ProcessTextMessageCommand(lineEvent));
+                _logger.LogInformation("成功處理文字訊息事件");
+                break;
+            case "audio":
+                await _mediator.Send(new ProcessAudioMessageCommand(lineEvent));
+                _logger.LogInformation("成功處理語音訊息事件");
+                break;
+            default:
+                _logger.LogDebug("跳過不支援的訊息類型: {MessageType}", lineEvent.Message?.Type);
+                break;
+        }
+    }
+
+    private async Task HandlePostbackEvent(LineEvent lineEvent)
+    {
+        if (lineEvent.Postback?.Data is null)
+        {
+            _logger.LogDebug("Postback 事件沒有 data 欄位");
+            return;
+        }
+
+        try
+        {
+            // 解析 Postback data: "action=publish&tenant_id=X&user_id=Y"
+            var postbackData = ParsePostbackData(lineEvent.Postback.Data);
+            
+            if (!postbackData.TryGetValue("action", out var action))
+            {
+                _logger.LogDebug("Postback data 缺少 action 參數: {Data}", lineEvent.Postback.Data);
+                return;
+            }
+
+            switch (action)
+            {
+                case "publish":
+                    await HandlePublishPostback(lineEvent);
+                    _logger.LogInformation("成功處理 publish postback 事件");
+                    break;
+                default:
+                    _logger.LogDebug("跳過不支援的 postback action: {Action}", action);
+                    break;
+            }
+        }
+        catch (MenuAlreadyPublishedException)
+        {
+            _logger.LogWarning("嘗試重複發布菜單: UserId={UserId}", 
+                lineEvent.Source.UserId);
+            // 這裡可以選擇不回覆或回覆已發布訊息
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "處理 Postback 事件時發生例外: Data={Data}", lineEvent.Postback.Data);
+        }
+    }
+
+    private async Task HandlePublishPostback(LineEvent lineEvent)
+    {
+        var tenantId = _tenantConfigService.GetTenantId();
+        var userId = lineEvent.Source.UserId;
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            _logger.LogWarning("Postback 事件缺少 user 資訊");
+            return;
+        }
+
+        var command = new PublishMenuCommand(tenantId, userId);
+        await _mediator.Send(command);
+    }
+
+    private static Dictionary<string, string> ParsePostbackData(string data)
+    {
+        var result = new Dictionary<string, string>();
+        
+        foreach (var pair in data.Split('&'))
+        {
+            var keyValue = pair.Split('=', 2);
+            if (keyValue.Length == 2)
+            {
+                result[keyValue[0]] = Uri.UnescapeDataString(keyValue[1]);
+            }
+        }
+
+        return result;
     }
 }

--- a/VeggieAlly/src/VeggieAlly.WebAPI/appsettings.json
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/appsettings.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "PostgreSQL": ""
+  },
   "AI": {
     "Provider": "ollama"
   },

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/DeductInventoryHandlerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/DeductInventoryHandlerTests.cs
@@ -1,0 +1,132 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Application.Menu.DeductInventory;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class DeductInventoryHandlerTests
+{
+    private readonly IPublishedMenuRepository _repository = Substitute.For<IPublishedMenuRepository>();
+    private readonly IPublishedMenuCache _cache = Substitute.For<IPublishedMenuCache>();
+    private readonly DeductInventoryHandler _handler;
+
+    public DeductInventoryHandlerTests()
+    {
+        _handler = new DeductInventoryHandler(_repository, _cache);
+    }
+
+    private static PublishedMenu CreateMenuWithItem(string itemId, int remainingQty = 50) => new()
+    {
+        Id = "menu-1",
+        TenantId = "tenant-1",
+        PublishedByUserId = "user-1",
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Items = [new PublishedMenuItem
+        {
+            Id = itemId,
+            MenuId = "menu-1",
+            Name = "高麗菜",
+            IsNew = false,
+            BuyPrice = 20m,
+            SellPrice = 35m,
+            OriginalQty = 50,
+            RemainingQty = remainingQty,
+            Unit = "箱"
+        }],
+        PublishedAt = DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public async Task Deduct_Valid_UpdatesDb()
+    {
+        _repository.DeductItemStockAsync("tenant-1", "item-1", 5, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.GetByTenantAndDateAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateMenuWithItem("item-1", 45));
+
+        var command = new DeductInventoryCommand("tenant-1", "item-1", 5);
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _repository.Received(1).DeductItemStockAsync("tenant-1", "item-1", 5, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Deduct_Valid_UpdatesCache()
+    {
+        _repository.DeductItemStockAsync("tenant-1", "item-1", 2, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.GetByTenantAndDateAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateMenuWithItem("item-1", 48));
+
+        var command = new DeductInventoryCommand("tenant-1", "item-1", 2);
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _cache.Received(1).SetAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Deduct_InsufficientStock_Throws()
+    {
+        _repository.DeductItemStockAsync("tenant-1", "item-1", 100, Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var command = new DeductInventoryCommand("tenant-1", "item-1", 100);
+
+        var ex = await Assert.ThrowsAsync<InsufficientStockException>(
+            () => _handler.Handle(command, CancellationToken.None));
+        Assert.Equal("item-1", ex.ItemId);
+    }
+
+    [Fact]
+    public async Task Deduct_ZeroAmount_ThrowsValidation()
+    {
+        var command = new DeductInventoryCommand("tenant-1", "item-1", 0);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Deduct_NegativeAmount_ThrowsValidation()
+    {
+        var command = new DeductInventoryCommand("tenant-1", "item-1", -5);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Deduct_CacheFails_StillSucceeds()
+    {
+        _repository.DeductItemStockAsync("tenant-1", "item-1", 3, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.GetByTenantAndDateAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateMenuWithItem("item-1", 47));
+        _cache.SetAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Redis down"));
+
+        var command = new DeductInventoryCommand("tenant-1", "item-1", 3);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(47, result.RemainingQty);
+    }
+
+    [Fact]
+    public async Task Deduct_ReturnsUpdatedItem()
+    {
+        _repository.DeductItemStockAsync("tenant-1", "item-1", 2, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.GetByTenantAndDateAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateMenuWithItem("item-1", 48));
+
+        var result = await _handler.Handle(
+            new DeductInventoryCommand("tenant-1", "item-1", 2), CancellationToken.None);
+
+        Assert.Equal("item-1", result.Id);
+        Assert.Equal(48, result.RemainingQty);
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/FlexMessageBuilderTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/FlexMessageBuilderTests.cs
@@ -184,4 +184,67 @@ public sealed class FlexMessageBuilderTests
 
         act.Should().Throw<ArgumentException>();
     }
+
+    // ── P3-002 新增測試 ──
+
+    [Fact]
+    public void BuildDraftBubble_AllOk_HasPublishButton()
+    {
+        var session = CreateDraftSession(
+            new DraftItem("id1", "高麗菜", false, 25, 35, 50, "箱", 24m, ValidationResult.Ok()),
+            new DraftItem("id2", "白蘿蔔", false, 18, 30, 30, "箱", 20m, ValidationResult.Ok()));
+
+        var result = _builder.BuildDraftBubble(session, "https://liff.example.com");
+        var json = Serialize(result);
+
+        // Footer 含 Postback 按鈕
+        json.Should().Contain("postback");
+        json.Should().Contain("一鍵發布");
+        json.Should().Contain("action=publish");
+    }
+
+    [Fact]
+    public void BuildDraftBubble_HasAnomaly_NoPublishButton()
+    {
+        var session = CreateDraftSession(
+            new DraftItem("id1", "高麗菜", false, 25, 35, 50, "箱", 24m, ValidationResult.Ok()),
+            new DraftItem("id2", "白蘿蔔", false, 30, 20, 30, "箱", 20m, ValidationResult.Anomaly("售價低於進價")));
+
+        var result = _builder.BuildDraftBubble(session, "https://liff.example.com");
+        var json = Serialize(result);
+
+        json.Should().NotContain("🚀 一鍵發布");
+        json.Should().Contain("點擊修正按鈕或重新傳送語音修正");
+    }
+
+    [Fact]
+    public void BuildPublishedBubble_ShowsConfirmation()
+    {
+        var menu = new VeggieAlly.Domain.Models.Menu.PublishedMenu
+        {
+            Id = "menu-1",
+            TenantId = "tenant-1",
+            PublishedByUserId = "user-1",
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Items = [new VeggieAlly.Domain.Models.Menu.PublishedMenuItem
+            {
+                Id = "item-1",
+                MenuId = "menu-1",
+                Name = "高麗菜",
+                SellPrice = 35m,
+                BuyPrice = 25m,
+                OriginalQty = 50,
+                RemainingQty = 50,
+                Unit = "箱"
+            }],
+            PublishedAt = DateTimeOffset.UtcNow
+        };
+
+        var result = _builder.BuildPublishedBubble(menu);
+        var json = Serialize(result);
+
+        json.Should().Contain("✅");
+        json.Should().Contain("菜單發布成功");
+        json.Should().Contain("高麗菜");
+    }
 }

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/GetTodayMenuHandlerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/GetTodayMenuHandlerTests.cs
@@ -1,0 +1,112 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Application.Menu.GetToday;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class GetTodayMenuHandlerTests
+{
+    private readonly IPublishedMenuCache _cache = Substitute.For<IPublishedMenuCache>();
+    private readonly IPublishedMenuRepository _repository = Substitute.For<IPublishedMenuRepository>();
+    private readonly GetTodayMenuHandler _handler;
+
+    public GetTodayMenuHandlerTests()
+    {
+        _handler = new GetTodayMenuHandler(_cache, _repository);
+    }
+
+    private static PublishedMenu CreateMenu() => new()
+    {
+        Id = Guid.NewGuid().ToString("N"),
+        TenantId = "tenant-1",
+        PublishedByUserId = "user-1",
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Items = [new PublishedMenuItem
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            MenuId = "menu-1",
+            Name = "高麗菜",
+            IsNew = false,
+            BuyPrice = 20m,
+            SellPrice = 35m,
+            OriginalQty = 50,
+            RemainingQty = 48,
+            Unit = "箱"
+        }],
+        PublishedAt = DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public async Task Get_CacheHit_ReturnsFromCache()
+    {
+        var menu = CreateMenu();
+        _cache.GetAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(menu);
+
+        var result = await _handler.Handle(new GetTodayMenuQuery("tenant-1"), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(menu.Id, result!.Id);
+        await _repository.DidNotReceive().GetByTenantAndDateAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_CacheMiss_DbHit_ReturnAndBackfill()
+    {
+        var menu = CreateMenu();
+        _cache.GetAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((PublishedMenu?)null);
+        _repository.GetByTenantAndDateAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(menu);
+
+        var result = await _handler.Handle(new GetTodayMenuQuery("tenant-1"), CancellationToken.None);
+
+        Assert.NotNull(result);
+        await _cache.Received(1).SetAsync(Arg.Is<PublishedMenu>(m => m.Id == menu.Id), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_CacheMissDbMiss_ReturnsNull()
+    {
+        _cache.GetAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((PublishedMenu?)null);
+        _repository.GetByTenantAndDateAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((PublishedMenu?)null);
+
+        var result = await _handler.Handle(new GetTodayMenuQuery("tenant-1"), CancellationToken.None);
+
+        Assert.Null(result);
+        await _cache.DidNotReceive().SetAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_CacheThrows_FallsBackToDb()
+    {
+        var menu = CreateMenu();
+        _cache.GetAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Redis failure"));
+        _repository.GetByTenantAndDateAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(menu);
+
+        var result = await _handler.Handle(new GetTodayMenuQuery("tenant-1"), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(menu.Id, result!.Id);
+    }
+
+    [Fact]
+    public async Task Get_CorrectTenantIsolation_PassesTenantIdToAll()
+    {
+        _cache.GetAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((PublishedMenu?)null);
+        _repository.GetByTenantAndDateAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((PublishedMenu?)null);
+
+        await _handler.Handle(new GetTodayMenuQuery("tenant-xyz"), CancellationToken.None);
+
+        await _cache.Received(1).GetAsync("tenant-xyz", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).GetByTenantAndDateAsync("tenant-xyz", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/InventoryControllerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/InventoryControllerTests.cs
@@ -1,0 +1,89 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Menu.DeductInventory;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.Domain.Models.Menu;
+using VeggieAlly.WebAPI.Controllers;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class InventoryControllerTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ILogger<InventoryController> _logger = Substitute.For<ILogger<InventoryController>>();
+    private readonly InventoryController _controller;
+
+    public InventoryControllerTests()
+    {
+        _controller = new InventoryController(_mediator, _logger);
+    }
+
+    [Fact]
+    public async Task Deduct_Valid_Returns200()
+    {
+        var updatedItem = new PublishedMenuItem
+        {
+            Id = "item-1",
+            MenuId = "menu-1",
+            Name = "高麗菜",
+            RemainingQty = 48,
+            Unit = "箱"
+        };
+        _mediator.Send(Arg.Any<DeductInventoryCommand>(), Arg.Any<CancellationToken>())
+            .Returns(updatedItem);
+
+        var request = new DeductInventoryRequest { ItemId = "item-1", Amount = 2 };
+        var result = await _controller.DeductInventory("tenant-1", request, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Deduct_InsufficientStock_Returns409()
+    {
+        _mediator.Send(Arg.Any<DeductInventoryCommand>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InsufficientStockException("item-1"));
+
+        var request = new DeductInventoryRequest { ItemId = "item-1", Amount = 100 };
+        var result = await _controller.DeductInventory("tenant-1", request, CancellationToken.None);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Deduct_MissingTenantId_Returns400()
+    {
+        var request = new DeductInventoryRequest { ItemId = "item-1", Amount = 2 };
+        var result = await _controller.DeductInventory("", request, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Deduct_InvalidArgument_Returns400()
+    {
+        _mediator.Send(Arg.Any<DeductInventoryCommand>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("扣除數量必須大於 0"));
+
+        var request = new DeductInventoryRequest { ItemId = "item-1", Amount = 1 };
+        var result = await _controller.DeductInventory("tenant-1", request, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Deduct_MenuNotPublished_Returns404()
+    {
+        _mediator.Send(Arg.Any<DeductInventoryCommand>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MenuNotPublishedException());
+
+        var request = new DeductInventoryRequest { ItemId = "item-1", Amount = 2 };
+        var result = await _controller.DeductInventory("tenant-1", request, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/MenuControllerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/MenuControllerTests.cs
@@ -1,0 +1,121 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Menu.DeductInventory;
+using VeggieAlly.Application.Menu.GetToday;
+using VeggieAlly.Application.Menu.Publish;
+using VeggieAlly.Application.Menu.Unpublish;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.Domain.Models.Menu;
+using VeggieAlly.WebAPI.Controllers;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class MenuControllerTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ILogger<MenuController> _logger = Substitute.For<ILogger<MenuController>>();
+    private readonly MenuController _controller;
+
+    public MenuControllerTests()
+    {
+        _controller = new MenuController(_mediator, _logger);
+    }
+
+    private static PublishedMenu CreateMenu() => new()
+    {
+        Id = "menu-1",
+        TenantId = "tenant-1",
+        PublishedByUserId = "user-1",
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Items = [new PublishedMenuItem
+        {
+            Id = "item-1",
+            MenuId = "menu-1",
+            Name = "高麗菜",
+            SellPrice = 35m,
+            BuyPrice = 20m,
+            OriginalQty = 50,
+            RemainingQty = 50,
+            Unit = "箱"
+        }],
+        PublishedAt = DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public async Task Publish_Valid_Returns201()
+    {
+        _mediator.Send(Arg.Any<PublishMenuCommand>(), Arg.Any<CancellationToken>())
+            .Returns(CreateMenu());
+
+        var result = await _controller.PublishMenu("tenant-1", "user-1", CancellationToken.None);
+
+        Assert.IsType<CreatedAtActionResult>(result);
+    }
+
+    [Fact]
+    public async Task Publish_AlreadyPublished_Returns409()
+    {
+        _mediator.Send(Arg.Any<PublishMenuCommand>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MenuAlreadyPublishedException());
+
+        var result = await _controller.PublishMenu("tenant-1", "user-1", CancellationToken.None);
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Publish_NoDraft_Returns404()
+    {
+        _mediator.Send(Arg.Any<PublishMenuCommand>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MenuNotPublishedException());
+
+        var result = await _controller.PublishMenu("tenant-1", "user-1", CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetToday_Exists_Returns200()
+    {
+        _mediator.Send(Arg.Any<GetTodayMenuQuery>(), Arg.Any<CancellationToken>())
+            .Returns(CreateMenu());
+
+        var result = await _controller.GetTodayMenu("tenant-1", CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetToday_NotExists_Returns404()
+    {
+        _mediator.Send(Arg.Any<GetTodayMenuQuery>(), Arg.Any<CancellationToken>())
+            .Returns((PublishedMenu?)null);
+
+        var result = await _controller.GetTodayMenu("tenant-1", CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetToday_EmptyTenantId_Returns400()
+    {
+        var result = await _controller.GetTodayMenu("", CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Unpublish_Returns501()
+    {
+        _mediator.Send(Arg.Any<UnpublishMenuCommand>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new NotImplementedException("撤回功能将在後續版本實作"));
+
+        var result = await _controller.UnpublishMenu("tenant-1", CancellationToken.None);
+
+        var objResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(501, objResult.StatusCode);
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/PublishMenuHandlerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/PublishMenuHandlerTests.cs
@@ -1,0 +1,196 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Common.Interfaces;
+using VeggieAlly.Application.Menu.Publish;
+using VeggieAlly.Domain.Abstractions;
+using VeggieAlly.Domain.Exceptions;
+using VeggieAlly.Domain.Models.Draft;
+using VeggieAlly.Domain.Models.Menu;
+using VeggieAlly.Domain.ValueObjects;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class PublishMenuHandlerTests
+{
+    private readonly IDraftSessionStore _draftStore = Substitute.For<IDraftSessionStore>();
+    private readonly IPublishedMenuRepository _repository = Substitute.For<IPublishedMenuRepository>();
+    private readonly IPublishedMenuCache _cache = Substitute.For<IPublishedMenuCache>();
+    private readonly PublishMenuHandler _handler;
+
+    public PublishMenuHandlerTests()
+    {
+        _handler = new PublishMenuHandler(_draftStore, _repository, _cache);
+    }
+
+    private static DraftMenuSession CreateDraftSession(int itemCount = 2) => new()
+    {
+        TenantId = "tenant-1",
+        LineUserId = "user-1",
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Items = Enumerable.Range(1, itemCount).Select(i => new DraftItem(
+            Id: Guid.NewGuid().ToString("N"),
+            Name: $"品項{i}",
+            IsNew: false,
+            BuyPrice: 20m + i,
+            SellPrice: 35m + i,
+            Quantity: 10 * i,
+            Unit: "箱",
+            HistoricalAvgPrice: 22m,
+            Validation: ValidationResult.Ok()
+        )).ToList(),
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public async Task Publish_AlreadyPublished_ThrowsAlreadyPublished()
+    {
+        _cache.ExistsAsync("tenant-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+
+        await Assert.ThrowsAsync<MenuAlreadyPublishedException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Publish_NoDraft_ThrowsMenuNotPublished()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((DraftMenuSession?)null);
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+
+        await Assert.ThrowsAsync<MenuNotPublishedException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Publish_EmptyDraft_ThrowsInvalidOp()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        var emptyDraft = CreateDraftSession(0);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(emptyDraft);
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Publish_Valid_InsertsDbAndCache()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDraftSession());
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _repository.Received(1).InsertAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>());
+        await _cache.Received(1).SetAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Publish_Valid_DeletesDraft()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDraftSession());
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+        await _handler.Handle(command, CancellationToken.None);
+
+        await _draftStore.Received(1).DeleteAsync("tenant-1", "user-1", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Publish_Valid_ReturnsPublishedMenu()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDraftSession());
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("tenant-1", result.TenantId);
+        Assert.Equal("user-1", result.PublishedByUserId);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task Publish_ItemsMapping_QuantityToOriginalAndRemaining()
+    {
+        var draft = CreateDraftSession(1);
+        draft.Items[0] = draft.Items[0] with { Quantity = 42 };
+
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(draft);
+
+        var result = await _handler.Handle(new PublishMenuCommand("tenant-1", "user-1"), CancellationToken.None);
+
+        var item = result.Items[0];
+        Assert.Equal(42, item.OriginalQty);
+        Assert.Equal(42, item.RemainingQty);
+    }
+
+    [Fact]
+    public async Task Publish_SetsPublisherId()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDraftSession());
+
+        var result = await _handler.Handle(new PublishMenuCommand("tenant-1", "user-abc"), CancellationToken.None);
+
+        Assert.Equal("user-abc", result.PublishedByUserId);
+    }
+
+    [Fact]
+    public async Task Publish_DbFails_DoesNotDeleteDraft()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDraftSession());
+        _repository.InsertAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("DB error"));
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+
+        await Assert.ThrowsAsync<Exception>(() => _handler.Handle(command, CancellationToken.None));
+        await _draftStore.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Publish_CacheFails_StillSucceeds()
+    {
+        _cache.ExistsAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _draftStore.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDraftSession());
+        _cache.SetAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Redis down"));
+
+        var command = new PublishMenuCommand("tenant-1", "user-1");
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotNull(result);
+        await _repository.Received(1).InsertAsync(Arg.Any<PublishedMenu>(), Arg.Any<CancellationToken>());
+        await _draftStore.Received(1).DeleteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/UnpublishMenuHandlerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/UnpublishMenuHandlerTests.cs
@@ -1,0 +1,16 @@
+using VeggieAlly.Application.Menu.Unpublish;
+
+namespace VeggieAlly.Application.Tests;
+
+public sealed class UnpublishMenuHandlerTests
+{
+    [Fact]
+    public async Task Unpublish_ThrowsNotImplemented()
+    {
+        var handler = new UnpublishMenuHandler();
+        var command = new UnpublishMenuCommand("tenant-1");
+
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/WebhookControllerTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/WebhookControllerTests.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using VeggieAlly.Application.Common.Interfaces;
 using VeggieAlly.Application.LineEvents.ProcessAudio;
 using VeggieAlly.Application.LineEvents.ProcessText;
+using VeggieAlly.Application.Menu.Publish;
 using VeggieAlly.Domain.Models.Line;
 using VeggieAlly.WebAPI.Controllers;
 
@@ -13,12 +15,14 @@ namespace VeggieAlly.Application.Tests;
 public sealed class WebhookControllerTests
 {
     private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ITenantConfigService _tenantConfigService = Substitute.For<ITenantConfigService>();
     private readonly ILogger<WebhookController> _logger = Substitute.For<ILogger<WebhookController>>();
     private readonly WebhookController _controller;
 
     public WebhookControllerTests()
     {
-        _controller = new WebhookController(_mediator, _logger);
+        _tenantConfigService.GetTenantId().Returns("default");
+        _controller = new WebhookController(_mediator, _tenantConfigService, _logger);
     }
 
     [Fact]
@@ -151,6 +155,65 @@ public sealed class WebhookControllerTests
             Arg.Any<ProcessAudioMessageCommand>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Audio Handler 爆了"));
+
+        var result = await _controller.Receive(payload);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task Receive_PostbackPublish_DispatchesPublishCommand()
+    {
+        var postbackEvent = new LineEvent(
+            Type: "postback",
+            ReplyToken: "reply-token-123",
+            Source: new LineEventSource("user", "U123"),
+            Message: null,
+            Postback: new LinePostback("action=publish"));
+        var payload = new LineWebhookPayload([postbackEvent]);
+
+        var result = await _controller.Receive(payload);
+
+        Assert.IsType<OkResult>(result);
+        await _mediator.Received(1).Send(
+            Arg.Is<PublishMenuCommand>(c => c.TenantId == "default" && c.LineUserId == "U123"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Receive_PostbackUnknownAction_Skips()
+    {
+        var postbackEvent = new LineEvent(
+            Type: "postback",
+            ReplyToken: "reply-token-123",
+            Source: new LineEventSource("user", "U123"),
+            Message: null,
+            Postback: new LinePostback("action=unknown_thing"));
+        var payload = new LineWebhookPayload([postbackEvent]);
+
+        var result = await _controller.Receive(payload);
+
+        Assert.IsType<OkResult>(result);
+        await _mediator.DidNotReceive().Send(
+            Arg.Any<PublishMenuCommand>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Receive_PostbackHandlerThrows_StillReturns200()
+    {
+        var postbackEvent = new LineEvent(
+            Type: "postback",
+            ReplyToken: "reply-token-123",
+            Source: new LineEventSource("user", "U123"),
+            Message: null,
+            Postback: new LinePostback("action=publish"));
+        var payload = new LineWebhookPayload([postbackEvent]);
+
+        _mediator.Send(
+            Arg.Any<PublishMenuCommand>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Publish Handler 爆了"));
 
         var result = await _controller.Receive(payload);
 

--- a/docs/specs/P3-002-publish-inventory-spec.md
+++ b/docs/specs/P3-002-publish-inventory-spec.md
@@ -1,0 +1,632 @@
+# P3-002: 一鍵發布鎖定 + 今日菜單 API + 庫存扣除 — SA/SD 規格藍圖
+
+## 文件資訊
+
+| 項目 | 值 |
+|------|---|
+| Phase | 3 |
+| 上游輸入 | `docs/菜商神隊友_PRD_v2_開發技術版.md` §3.4, §4 |
+| 前置完成 | P3-001（Redis 草稿管理 + 雙軌修正 API） |
+| 下游消費者 | 前端 PG（LIFF 今日菜單）、後端 PG（庫存扣除） |
+| 狀態 | Draft |
+
+---
+
+## 1. 系統邊界定義
+
+### Scope 內
+- 一鍵發布：草稿 → 發布菜單（Redis published key + DB 持久化）
+- 發布鎖定：已發布後刪除草稿，自然阻斷修改
+- `POST /api/menu/publish`：LINE Postback → 發布
+- `DELETE /api/menu/publish`：撤回（MVP 回傳 501）
+- `GET /api/menu/today?tenant_id={id}`：今日已發布菜單
+- `PATCH /api/menu/inventory`：庫存扣除（PostgreSQL Row-Level Lock）
+- Redis write-through 快取已發布菜單
+- FlexMessageBuilder 更新：Footer 加 🚀 發布按鈕（Postback Action）
+- PostgreSQL schema（published_menus + published_menu_items）
+- Dapper + Npgsql 引入
+
+### Scope 外
+- LIFF 銷售端前端（P3-003）
+- 歷史菜單查詢
+- 批次庫存匯入
+
+---
+
+## 2. 架構決策紀錄
+
+### ADR-001: PostgreSQL + Dapper 引入策略
+
+**決策**：引入 Npgsql + Dapper，透過 `IDbConnectionFactory` 抽象管理連線。
+
+**理由**：PRD 規定 Dapper + Repository Pattern + 手寫 SQL。`NpgsqlDataSource` (Npgsql 8+) 作為 DI Singleton，提供連線池。Repository 接受 `NpgsqlDataSource`。
+
+### ADR-002: Published Menu vs Draft 資料模型分離
+
+**決策**：`PublishedMenu` / `PublishedMenuItem` 為獨立 Domain Entity，不複用 `DraftMenuSession`。
+
+**理由**：發布後的菜單有 `remaining_qty`（剩餘庫存）、`published_at` 等草稿不具備的欄位。生命週期也不同：草稿 24h TTL，已發布菜單存 DB 永久保留。
+
+### ADR-003: 發布鎖定機制
+
+**決策**：Redis `EXISTS` check + DB `UNIQUE(tenant_id, date)` 雙重保障。發布成功後刪除草稿。
+
+**理由**：
+1. 快速路徑：先 Redis check `{tenant_id}:menu:published:{date}` 是否存在，存在即回 409
+2. DB UNIQUE 約束兜底：即使 Redis 故障，DB 層面也保證每天每租戶只能發布一次
+3. 刪除草稿：發布後呼叫 `IDraftSessionStore.DeleteAsync`，自然阻斷後續修改
+
+### ADR-004: 庫存扣除併發策略
+
+**決策**：`UPDATE ... WHERE remaining_qty >= @amount` + DB `CHECK(remaining_qty >= 0)` 雙重保障。
+
+**理由**：Row-Level Lock 是 PostgreSQL 預設行為（UPDATE 自動取得 row lock）。`WHERE remaining_qty >= @amount` 是樂觀鎖語義——如果庫存不足，`affected == 0`，拋出 `InsufficientStockException`。`CHECK` 約束作為第二層保險。
+
+### ADR-005: Redis Write-Through 一致性
+
+**決策**：DB commit 後重新讀取整份菜單覆寫 Redis cache。
+
+**理由**：避免部分更新造成不一致。代價是一次額外 SELECT，但菜單通常 < 50 品項，query 極快。
+
+### ADR-006: Flex Message Footer 🚀 按鈕
+
+**決策**：使用 LINE Postback Action，data 欄位帶 `action=publish&tenant_id={id}&user_id={userId}`。
+
+**理由**：Postback 不汙染使用者文字輸入管線（不觸發 LLM 解析），且可攜帶結構化參數。WebhookController 新增 Postback event handler。
+
+### ADR-007: 撤回功能預留
+
+**決策**：定義 `UnpublishMenuCommand` 介面，MVP 實作回傳 501 Not Implemented。
+
+**理由**：完整撤回涉及已扣庫存回滾問題，MVP 不處理。介面預留可在後續 phase 實作。
+
+---
+
+## 3. Sequence Diagrams
+
+### 3.1 發布流程
+
+```mermaid
+sequenceDiagram
+    participant User as LINE User
+    participant LINE as LINE Platform
+    participant WH as WebhookController
+    participant PH as PublishMenuHandler
+    participant DS as IDraftSessionStore
+    participant DB as PostgreSQL
+    participant RC as Redis Cache
+
+    User->>LINE: 點擊🚀一鍵發布
+    LINE->>WH: Postback Event (action=publish)
+    WH->>PH: Send(PublishMenuCommand)
+    PH->>RC: EXISTS {tenant}:menu:published:{date}
+    alt 已發布
+        PH-->>WH: MenuAlreadyPublishedException
+        WH->>LINE: Reply "今日菜單已發布"
+    else 未發布
+        PH->>DS: GetAsync(tenant, user, date)
+        DS-->>PH: DraftMenuSession
+        PH->>DB: INSERT published_menus + published_menu_items
+        PH->>RC: SET {tenant}:menu:published:{date} (write-through)
+        PH->>DS: DeleteAsync(tenant, user, date)
+        PH-->>WH: PublishedMenu
+        WH->>LINE: Reply Flex "✅ 菜單已發布"
+    end
+```
+
+### 3.2 庫存扣除流程
+
+```mermaid
+sequenceDiagram
+    participant Client as LIFF Client
+    participant IC as InventoryController
+    participant DI as DeductInventoryHandler
+    participant DB as PostgreSQL
+    participant RC as Redis Cache
+
+    Client->>IC: PATCH /api/menu/inventory
+    IC->>DI: Send(DeductInventoryCommand)
+    DI->>DB: BEGIN TX
+    DI->>DB: UPDATE remaining_qty WHERE qty >= amount
+    alt affected == 0
+        DI->>DB: ROLLBACK
+        DI-->>IC: InsufficientStockException
+        IC-->>Client: 409 Conflict
+    else affected > 0
+        DI->>DB: COMMIT
+        DI->>DB: SELECT full menu (re-read)
+        DI->>RC: SET cache (write-through)
+        DI-->>IC: Updated item
+        IC-->>Client: 200 OK
+    end
+```
+
+### 3.3 查詢流程
+
+```mermaid
+sequenceDiagram
+    participant Client as LIFF Client
+    participant MC as MenuController
+    participant QH as GetTodayMenuHandler
+    participant RC as Redis Cache
+    participant DB as PostgreSQL
+
+    Client->>MC: GET /api/menu/today?tenant_id=X
+    MC->>QH: Send(GetTodayMenuQuery)
+    QH->>RC: GET {tenant}:menu:published:{date}
+    alt Cache Hit
+        RC-->>QH: PublishedMenu JSON
+    else Cache Miss
+        QH->>DB: SELECT published_menus + items
+        alt DB 有資料
+            DB-->>QH: PublishedMenu
+            QH->>RC: SET cache (回填)
+            QH-->>MC: PublishedMenu
+        else DB 無資料
+            QH-->>MC: null
+            MC-->>Client: 404 Not Found
+        end
+    end
+    MC-->>Client: 200 OK + Menu JSON
+```
+
+---
+
+## 4. Domain Model
+
+### 4.1 PublishedMenu
+
+```csharp
+namespace VeggieAlly.Domain.Models.Menu;
+
+public sealed class PublishedMenu
+{
+    public required string Id { get; init; }              // GUID "N" 格式
+    public required string TenantId { get; init; }
+    public required string PublishedByUserId { get; init; }
+    public required DateOnly Date { get; init; }
+    public required List<PublishedMenuItem> Items { get; init; }
+    public required DateTimeOffset PublishedAt { get; init; }
+}
+```
+
+### 4.2 PublishedMenuItem
+
+```csharp
+namespace VeggieAlly.Domain.Models.Menu;
+
+public sealed class PublishedMenuItem
+{
+    public required string Id { get; init; }              // GUID "N" 格式
+    public required string MenuId { get; init; }
+    public required string Name { get; init; }
+    public bool IsNew { get; init; }
+    public decimal BuyPrice { get; init; }
+    public decimal SellPrice { get; init; }
+    public int OriginalQty { get; init; }
+    public int RemainingQty { get; set; }
+    public required string Unit { get; init; }
+    public decimal? HistoricalAvgPrice { get; init; }
+}
+```
+
+### 4.3 Exceptions
+
+```csharp
+namespace VeggieAlly.Domain.Exceptions;
+
+public sealed class InsufficientStockException : Exception
+{
+    public string ItemId { get; }
+    public InsufficientStockException(string itemId)
+        : base($"庫存不足: {itemId}") => ItemId = itemId;
+}
+
+public sealed class MenuAlreadyPublishedException : Exception
+{
+    public MenuAlreadyPublishedException()
+        : base("今日菜單已發布") { }
+}
+
+public sealed class MenuNotPublishedException : Exception
+{
+    public MenuNotPublishedException()
+        : base("尚未發布菜單") { }
+}
+```
+
+---
+
+## 5. Application Layer
+
+### 5.1 Interfaces
+
+```csharp
+// IPublishedMenuRepository — Dapper Repository
+namespace VeggieAlly.Application.Common.Interfaces;
+
+public interface IPublishedMenuRepository
+{
+    Task<PublishedMenu?> GetByTenantAndDateAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+    Task InsertAsync(PublishedMenu menu, CancellationToken ct = default);
+    Task<int> DeductItemStockAsync(string tenantId, string itemId, int amount, CancellationToken ct = default);
+    Task DeleteByTenantAndDateAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+}
+```
+
+```csharp
+// IPublishedMenuCache — Redis Cache
+namespace VeggieAlly.Application.Common.Interfaces;
+
+public interface IPublishedMenuCache
+{
+    Task<PublishedMenu?> GetAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+    Task SetAsync(PublishedMenu menu, CancellationToken ct = default);
+    Task RemoveAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+    Task<bool> ExistsAsync(string tenantId, DateOnly date, CancellationToken ct = default);
+}
+```
+
+### 5.2 Commands & Queries
+
+```csharp
+// PublishMenuCommand
+public sealed record PublishMenuCommand(
+    string TenantId, string LineUserId) : IRequest<PublishedMenu>;
+
+// UnpublishMenuCommand (MVP: 501)
+public sealed record UnpublishMenuCommand(
+    string TenantId) : IRequest;
+
+// GetTodayMenuQuery
+public sealed record GetTodayMenuQuery(
+    string TenantId) : IRequest<PublishedMenu?>;
+
+// DeductInventoryCommand
+public sealed record DeductInventoryCommand(
+    string TenantId, string ItemId, int Amount) : IRequest<PublishedMenuItem>;
+```
+
+### 5.3 PublishMenuHandler 邏輯
+
+```
+1. cache.ExistsAsync → 已存在 → throw MenuAlreadyPublishedException
+2. draftStore.GetAsync → null → throw MenuNotPublishedException (草稿不存在)
+3. 將 DraftMenuSession.Items 轉換為 PublishedMenu + PublishedMenuItems
+4. repository.InsertAsync (DB persist)
+5. cache.SetAsync (Redis write-through)
+6. draftStore.DeleteAsync (刪除草稿，鎖定)
+7. return PublishedMenu
+```
+
+### 5.4 DeductInventoryHandler 邏輯
+
+```
+1. repository.DeductItemStockAsync(tenantId, itemId, amount)
+2. if affected == 0 → throw InsufficientStockException
+3. repository.GetByTenantAndDateAsync → 重新讀取完整菜單
+4. cache.SetAsync (write-through 更新)
+5. return updated PublishedMenuItem
+```
+
+### 5.5 GetTodayMenuHandler 邏輯
+
+```
+1. cache.GetAsync → hit → return
+2. miss → repository.GetByTenantAndDateAsync
+3. found → cache.SetAsync (回填) → return
+4. not found → return null
+```
+
+---
+
+## 6. Infrastructure Layer
+
+### 6.1 PostgreSQL Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS published_menus (
+    id              VARCHAR(32)     PRIMARY KEY,
+    tenant_id       VARCHAR(64)     NOT NULL,
+    published_by    VARCHAR(64)     NOT NULL,
+    date            DATE            NOT NULL,
+    published_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_published_menus_tenant_date UNIQUE (tenant_id, date)
+);
+
+CREATE INDEX idx_published_menus_tenant_date ON published_menus (tenant_id, date);
+
+CREATE TABLE IF NOT EXISTS published_menu_items (
+    id                  VARCHAR(32)     PRIMARY KEY,
+    menu_id             VARCHAR(32)     NOT NULL REFERENCES published_menus(id) ON DELETE CASCADE,
+    tenant_id           VARCHAR(64)     NOT NULL,
+    name                VARCHAR(128)    NOT NULL,
+    is_new              BOOLEAN         NOT NULL DEFAULT FALSE,
+    buy_price           DECIMAL(10,2)   NOT NULL,
+    sell_price          DECIMAL(10,2)   NOT NULL,
+    original_qty        INT             NOT NULL,
+    remaining_qty       INT             NOT NULL,
+    unit                VARCHAR(16)     NOT NULL,
+    historical_avg_price DECIMAL(10,2),
+    CONSTRAINT chk_remaining_qty CHECK (remaining_qty >= 0)
+);
+
+CREATE INDEX idx_published_menu_items_menu_id ON published_menu_items (menu_id);
+CREATE INDEX idx_published_menu_items_tenant ON published_menu_items (tenant_id);
+```
+
+### 6.2 Dapper Repository 核心 SQL
+
+```csharp
+// InsertAsync
+INSERT INTO published_menus (id, tenant_id, published_by, date, published_at)
+VALUES (@Id, @TenantId, @PublishedByUserId, @Date, @PublishedAt);
+
+INSERT INTO published_menu_items (id, menu_id, tenant_id, name, is_new, buy_price, sell_price, original_qty, remaining_qty, unit, historical_avg_price)
+VALUES (@Id, @MenuId, @TenantId, @Name, @IsNew, @BuyPrice, @SellPrice, @OriginalQty, @RemainingQty, @Unit, @HistoricalAvgPrice);
+
+// GetByTenantAndDateAsync
+SELECT * FROM published_menus WHERE tenant_id = @TenantId AND date = @Date;
+SELECT * FROM published_menu_items WHERE menu_id = @MenuId AND tenant_id = @TenantId;
+
+// DeductItemStockAsync
+UPDATE published_menu_items
+SET remaining_qty = remaining_qty - @Amount
+WHERE id = @ItemId AND tenant_id = @TenantId AND remaining_qty >= @Amount;
+
+// DeleteByTenantAndDateAsync
+DELETE FROM published_menus WHERE tenant_id = @TenantId AND date = @Date;
+```
+
+### 6.3 Redis Published Menu Cache
+
+- Key: `{tenantId}:menu:published:{yyyy-MM-dd}`
+- TTL: 計算至當日 23:59:59 (台灣時間) 剩餘秒數
+- 序列化: JSON (`JsonNamingPolicy.SnakeCaseLower`)
+
+### 6.4 NuGet 新增
+
+```xml
+<PackageReference Include="Npgsql" Version="9.0.*" />
+<PackageReference Include="Dapper" Version="2.1.*" />
+```
+
+---
+
+## 7. WebAPI Layer
+
+### 7.1 MenuController
+
+```
+[ApiController]
+[Route("api/menu")]
+
+POST   /api/menu/publish       [LiffAuth] → PublishMenuCommand → 201 / 409
+DELETE /api/menu/publish       [LiffAuth] → UnpublishMenuCommand → 501 (MVP)
+GET    /api/menu/today         ?tenant_id={id} → GetTodayMenuQuery → 200 / 404
+```
+
+### 7.2 InventoryController
+
+```
+[ApiController]
+[Route("api/menu")]
+
+PATCH  /api/menu/inventory     [LiffAuth] → DeductInventoryCommand → 200 / 409 / 400
+```
+
+### 7.3 DTO 定義
+
+```csharp
+// PublishedMenuDto (GET response)
+{
+    "id": "...",
+    "tenant_id": "...",
+    "date": "2026-04-04",
+    "published_at": "...",
+    "items": [
+        {
+            "id": "...",
+            "name": "初秋高麗菜",
+            "is_new": false,
+            "sell_price": 35.00,
+            "original_qty": 50,
+            "remaining_qty": 48,
+            "unit": "箱"
+        }
+    ]
+}
+
+// DeductInventoryRequest (PATCH body)
+{
+    "item_id": "...",
+    "amount": 2
+}
+```
+
+---
+
+## 8. 整合點（與 P3-001）
+
+### 8.1 發布時讀取草稿
+- `PublishMenuHandler` 呼叫 `IDraftSessionStore.GetAsync` 取得 `DraftMenuSession`
+- 將 `DraftItem[]` 轉換為 `PublishedMenuItem[]`（`Quantity` → `OriginalQty` = `RemainingQty`）
+
+### 8.2 發布後刪除草稿
+- `PublishMenuHandler` 呼叫 `IDraftSessionStore.DeleteAsync` 刪除草稿
+- 自然阻斷後續 PATCH /api/draft/item/{id} 修改
+
+### 8.3 FlexMessageBuilder 更新
+- `BuildDraftBubble` 的 Footer 改為：
+  - 有異常品項 → 只顯示 "💡 點擊修正按鈕或重新傳送語音修正"
+  - 全部 Ok → 顯示 🚀 一鍵發布 Postback 按鈕
+- 新增 `BuildPublishedBubble(PublishedMenu)` — 發布確認卡片
+
+### 8.4 Webhook Postback 處理
+- PostbackEvent handler 解析 `data=action=publish&tenant_id=X&user_id=Y`
+- 路由到 `PublishMenuCommand`
+
+---
+
+## 9. 安全設計
+
+| # | OWASP | 對策 |
+|---|-------|------|
+| 1 | A01 Broken Access Control | Tenant 隔離：所有 SQL 帶 tenant_id；Redis key 含 tenant prefix |
+| 2 | A01 | 發布/庫存端點需 LiffAuth 驗證 |
+| 3 | A03 Injection | Dapper 參數化查詢，禁止字串拼接 SQL |
+| 4 | A04 Insecure Design | 庫存 CHECK 約束 + WHERE 條件雙重防超賣 |
+| 5 | A05 Security Misconfiguration | DB 連線字串從環境變數讀取，不硬編碼 |
+| 6 | A08 Data Integrity | DB UNIQUE 約束防重複發布 |
+| 7 | A10 SSRF | 無外部 URL 拉取 |
+
+---
+
+## 10. 單元測試清單
+
+### 10.1 PublishMenuHandlerTests（10 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Publish_NoDraft_ThrowsMenuNotPublished` | exception |
+| 2 | `Publish_AlreadyPublished_ThrowsAlreadyPublished` | exception |
+| 3 | `Publish_Valid_InsertsDbAndCache` | DB + Redis called |
+| 4 | `Publish_Valid_DeletesDraft` | DeleteAsync called |
+| 5 | `Publish_Valid_ReturnsPublishedMenu` | correct mapping |
+| 6 | `Publish_ItemsMapping_QuantityToOriginalAndRemaining` | OriginalQty == RemainingQty == DraftItem.Quantity |
+| 7 | `Publish_SetsPublisherId` | PublishedByUserId == lineUserId |
+| 8 | `Publish_DbFails_DoesNotDeleteDraft` | exception, draft preserved |
+| 9 | `Publish_CacheFails_StillSucceeds` | DB persisted, cache degraded |
+| 10 | `Publish_EmptyDraft_ThrowsInvalidOp` | exception for 0 items |
+
+### 10.2 GetTodayMenuHandlerTests（5 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Get_CacheHit_ReturnsFromCache` | cache called, DB not called |
+| 2 | `Get_CacheMiss_DbHit_ReturnAndBackfill` | DB called, cache.SetAsync called |
+| 3 | `Get_CacheMissDbMiss_ReturnsNull` | null |
+| 4 | `Get_CacheThrows_FallsBackToDb` | DB called |
+| 5 | `Get_CorrectTenantIsolation` | only own tenant data |
+
+### 10.3 DeductInventoryHandlerTests（7 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Deduct_Valid_UpdatesDb` | DeductItemStockAsync called |
+| 2 | `Deduct_Valid_UpdatesCache` | cache.SetAsync called |
+| 3 | `Deduct_InsufficientStock_Throws` | InsufficientStockException |
+| 4 | `Deduct_ZeroAmount_ThrowsValidation` | ArgumentException |
+| 5 | `Deduct_NegativeAmount_ThrowsValidation` | ArgumentException |
+| 6 | `Deduct_CacheFails_StillSucceeds` | DB updated |
+| 7 | `Deduct_ReturnsUpdatedItem` | correct remaining qty |
+
+### 10.4 UnpublishMenuHandlerTests（1 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Unpublish_ThrowsNotImplemented` | NotImplementedException |
+
+### 10.5 MenuControllerTests（8 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Publish_Valid_Returns201` | 201 Created |
+| 2 | `Publish_AlreadyPublished_Returns409` | 409 Conflict |
+| 3 | `Publish_NoDraft_Returns404` | 404 |
+| 4 | `GetToday_Exists_Returns200` | 200 + body |
+| 5 | `GetToday_NotExists_Returns404` | 404 |
+| 6 | `GetToday_EmptyTenantId_Returns400` | 400 |
+| 7 | `Unpublish_Returns501` | 501 |
+| 8 | `Inventory_Valid_Returns200` | 200 |
+
+### 10.6 InventoryControllerTests（5 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Deduct_Valid_Returns200` | 200 + updated item |
+| 2 | `Deduct_InsufficientStock_Returns409` | 409 |
+| 3 | `Deduct_ZeroAmount_Returns400` | 400 |
+| 4 | `Deduct_NegativeAmount_Returns400` | 400 |
+| 5 | `Deduct_MissingItemId_Returns400` | 400 |
+
+### 10.7 PublishedMenuRepositoryTests（6 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Insert_ThenGet_ReturnsSame` | round-trip |
+| 2 | `Get_NonExistent_ReturnsNull` | null |
+| 3 | `Deduct_Sufficient_ReturnsAffected` | affected == 1 |
+| 4 | `Deduct_InsufficientQty_Returns0` | affected == 0 |
+| 5 | `Delete_ThenGet_ReturnsNull` | null |
+| 6 | `Insert_Duplicate_ThrowsUniqueViolation` | exception |
+
+### 10.8 PublishedMenuCacheTests（5 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Set_ThenGet_ReturnsSame` | round-trip |
+| 2 | `Get_NonExistent_ReturnsNull` | null |
+| 3 | `Exists_AfterSet_ReturnsTrue` | true |
+| 4 | `Exists_BeforeSet_ReturnsFalse` | false |
+| 5 | `Remove_ThenExists_ReturnsFalse` | false |
+
+### 10.9 FlexMessageBuilder 擴充（3 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `BuildDraftBubble_AllOk_HasPublishButton` | Footer 含 🚀 Postback |
+| 2 | `BuildDraftBubble_HasAnomaly_NoPublishButton` | Footer 無按鈕 |
+| 3 | `BuildPublishedBubble_ShowsConfirmation` | 含 ✅ 確認訊息 |
+
+### 10.10 WebhookController Postback 擴充（3 案例）
+
+| # | 測試 | 預期 |
+|---|------|------|
+| 1 | `Receive_PostbackPublish_DispatchesCommand` | PublishMenuCommand sent |
+| 2 | `Receive_PostbackUnknown_Skips` | no dispatch |
+| 3 | `Receive_PostbackHandlerThrows_Returns200` | 200 (LINE 需要) |
+
+**總計**：新增 ~53 個測試案例 + 修改既有測試。
+
+---
+
+## 11. 檔案清單
+
+### 新增
+
+| # | 路徑 | 說明 |
+|---|------|------|
+| 1 | `src/VeggieAlly.Domain/Models/Menu/PublishedMenu.cs` | Domain entity |
+| 2 | `src/VeggieAlly.Domain/Models/Menu/PublishedMenuItem.cs` | Domain entity |
+| 3 | `src/VeggieAlly.Domain/Exceptions/InsufficientStockException.cs` | Domain exception |
+| 4 | `src/VeggieAlly.Domain/Exceptions/MenuAlreadyPublishedException.cs` | Domain exception |
+| 5 | `src/VeggieAlly.Domain/Exceptions/MenuNotPublishedException.cs` | Domain exception |
+| 6 | `src/VeggieAlly.Application/Common/Interfaces/IPublishedMenuRepository.cs` | Dapper repo interface |
+| 7 | `src/VeggieAlly.Application/Common/Interfaces/IPublishedMenuCache.cs` | Redis cache interface |
+| 8 | `src/VeggieAlly.Application/Menu/Publish/PublishMenuCommand.cs` | Command |
+| 9 | `src/VeggieAlly.Application/Menu/Publish/PublishMenuHandler.cs` | Handler |
+| 10 | `src/VeggieAlly.Application/Menu/Unpublish/UnpublishMenuCommand.cs` | Command (501) |
+| 11 | `src/VeggieAlly.Application/Menu/Unpublish/UnpublishMenuHandler.cs` | Handler (501) |
+| 12 | `src/VeggieAlly.Application/Menu/GetToday/GetTodayMenuQuery.cs` | Query |
+| 13 | `src/VeggieAlly.Application/Menu/GetToday/GetTodayMenuHandler.cs` | Handler |
+| 14 | `src/VeggieAlly.Application/Menu/DeductInventory/DeductInventoryCommand.cs` | Command |
+| 15 | `src/VeggieAlly.Application/Menu/DeductInventory/DeductInventoryHandler.cs` | Handler |
+| 16 | `src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs` | Dapper impl |
+| 17 | `src/VeggieAlly.Infrastructure/Cache/PublishedMenuCache.cs` | Redis cache impl |
+| 18 | `src/VeggieAlly.WebAPI/Controllers/MenuController.cs` | API controller |
+| 19 | `src/VeggieAlly.WebAPI/Controllers/InventoryController.cs` | API controller |
+| 20 | `db/migrations/001_create_published_menus.sql` | DDL script |
+
+### 修改
+
+| # | 路徑 | 說明 |
+|---|------|------|
+| 1 | `src/VeggieAlly.Infrastructure/DependencyInjection.cs` | +Repository +Cache +Npgsql DI |
+| 2 | `src/VeggieAlly.Infrastructure/VeggieAlly.Infrastructure.csproj` | +Npgsql +Dapper |
+| 3 | `src/VeggieAlly.Application/Services/FlexMessageBuilder.cs` | +BuildPublishedBubble +Footer 🚀按鈕 |
+| 4 | `src/VeggieAlly.Application/Common/Interfaces/IFlexMessageBuilder.cs` | +BuildPublishedBubble |
+| 5 | `src/VeggieAlly.WebAPI/Controllers/WebhookController.cs` | +Postback handler |
+| 6 | `src/VeggieAlly.WebAPI/appsettings.json` | +PostgreSQL ConnectionString |
+| 7 | `src/VeggieAlly.WebAPI/Program.cs` | +NpgsqlDataSource +new services |
+| 8 | `docker-compose.yml` | +postgres service |


### PR DESCRIPTION
## P3-002: 發布菜單與庫存扣減

### 變更摘要
實作 PRD §3.4 發布菜單流程 + §4 庫存扣減功能，基於 P3-001 Redis 草稿基礎之上。

### 新增功能
- **發布菜單**: 草稿全品項 Ok → 🚀 Postback 按鈕 → Cache check → DB 持久化 → Redis write-through → 刪除草稿
- **查詢今日菜單**: Cache 優先 → DB fallback → 自動回填 Cache
- **庫存扣減**: Row-Level Lock 確保並發安全, Cache write-through 更新
- **撤回發布**: MVP 回傳 501 Not Implemented

### 架構
- **Domain**: `PublishedMenu`/`PublishedMenuItem` 實體, 3 Exception 類型, `LinePostback` record
- **Application**: 4 個 CQRS Handler (Publish/GetToday/Deduct/Unpublish)
- **Infrastructure**: `PublishedMenuRepository` (Dapper+Npgsql 參數化查詢), `PublishedMenuCache` (Redis), `NoOpPublishedMenuCache` (Redis 不可用時 fallback)
- **WebAPI**: `MenuController` + `InventoryController` (全部 `[LiffAuth]` 保護), WebhookController postback 處理
- **DB**: `001_create_published_menus.sql` (UNIQUE tenant+date, CHECK constraints)
- **Docker**: 新增 PostgreSQL 16 service

### 安全性
- 所有新端點皆加 `[LiffAuth]` 授權驗證 (QA/QC 安全審核後修正)
- SQL 全部參數化 (Dapper `@param`)
- Row-Level Lock: `WHERE remaining_qty >= @Amount`
- Tenant 隔離: SQL + Redis key prefix
- `DeductInventoryRequest` 加上 `[JsonPropertyName]` 確保 snake_case 契約

### 測試
- **159/159 測試全通過** (118 原有 + 41 新增)
- 新增 7 個測試檔案，擴充 2 個既有測試檔案
- 涵蓋: Handler 邏輯、Controller 路由、Postback 分派、Tenant 隔離、Cache 降級

### 待後續
- Repository/Cache 整合測試 (需 PG/Redis 環境)
- 全域 Exception Filter (非本 phase 範疇)

Closes #17