### PR TITLE
fix(review): address all PR review comments for M-2~M-9 fixes

### DIFF
--- a/VeggieAlly/liff-app/src/pages/NumPadPage.vue
+++ b/VeggieAlly/liff-app/src/pages/NumPadPage.vue
@@ -74,12 +74,28 @@ const itemInfo = ref({
 
 // QueryString 參數
 const itemId = computed(() => {
-  const value = route.query.item_id
+  const value = route.query.itemId || route.query.item_id // 支援新舊格式
   return typeof value === 'string' ? value : ''
 })
 const field = computed(() => {
   const value = route.query.field
   return typeof value === 'string' ? value : ''
+})
+
+// 新增：從 URL 讀取品項資料
+const itemName = computed(() => {
+  const value = route.query.itemName
+  return typeof value === 'string' ? value : '未知品項'
+})
+const buyPrice = computed(() => {
+  const value = route.query.buyPrice
+  const price = parseInt(typeof value === 'string' ? value : '0', 10)
+  return isNaN(price) ? 0 : price
+})
+const sellPrice = computed(() => {
+  const value = route.query.sellPrice
+  const price = parseInt(typeof value === 'string' ? value : '0', 10)
+  return isNaN(price) ? 0 : price
 })
 
 // 顯示相關計算
@@ -122,12 +138,18 @@ function validateQueryParams(): void {
 // 載入品項資訊
 async function loadItemInfo(): Promise<void> {
   try {
-    // 根據規格，我們需要先 GET item 資訊來顯示當前價格和名稱
-    // 但這裡沒有對應的 GET API，所以我們先用預設值
-    // 實際應該要有 GET /api/draft/item/{id} API
+    // 檢查是否缺少必要參數
+    if (buyPrice.value === 0) {
+      console.warn('URL 缺少 buyPrice 參數或值為 0')
+    }
+    if (sellPrice.value === 0) {
+      console.warn('URL 缺少 sellPrice 參數或值為 0')
+    }
+    
+    // 從 URL query string 讀取品項資料
     itemInfo.value = {
-      name: `品項 ${itemId.value.slice(0, 8)}...`,
-      currentPrice: field.value === 'buy_price' ? 25 : 35
+      name: itemName.value,
+      currentPrice: field.value === 'buy_price' ? buyPrice.value : sellPrice.value
     }
   } catch (error) {
     console.error('載入品項資訊失敗:', error)

--- a/VeggieAlly/liff-app/src/pages/NumPadPage.vue
+++ b/VeggieAlly/liff-app/src/pages/NumPadPage.vue
@@ -79,7 +79,13 @@ const itemId = computed(() => {
 })
 const field = computed(() => {
   const value = route.query.field
-  return typeof value === 'string' ? value : ''
+  if (typeof value === 'string') {
+    return value
+  }
+  
+  // Graceful fallback: 缺少 field 參數時預設為 buy_price
+  console.warn('URL 缺少 field 參數，預設使用 buy_price')
+  return 'buy_price'
 })
 
 // 新增：從 URL 讀取品項資料
@@ -124,11 +130,7 @@ function validateQueryParams(): void {
     return
   }
   
-  if (!field.value) {
-    validationError.value = '缺少欄位參數'
-    return
-  }
-  
+  // 移除 field 參數的強制檢查，改為在 computed 中處理 fallback
   if (!validFields.includes(field.value)) {
     validationError.value = '無效的欄位參數'
     return

--- a/VeggieAlly/liff-app/src/pages/NumPadPage.vue
+++ b/VeggieAlly/liff-app/src/pages/NumPadPage.vue
@@ -79,13 +79,8 @@ const itemId = computed(() => {
 })
 const field = computed(() => {
   const value = route.query.field
-  if (typeof value === 'string') {
-    return value
-  }
-  
   // Graceful fallback: 缺少 field 參數時預設為 buy_price
-  console.warn('URL 缺少 field 參數，預設使用 buy_price')
-  return 'buy_price'
+  return typeof value === 'string' ? value : 'buy_price'
 })
 
 // 新增：從 URL 讀取品項資料
@@ -248,6 +243,9 @@ function handleCancel(): void {
 
 // 初始化
 onMounted(() => {
+  if (typeof route.query.field !== 'string') {
+    console.warn('URL 缺少 field 參數，預設使用 buy_price')
+  }
   validateQueryParams()
   if (!validationError.value) {
     loadItemInfo()

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs
@@ -96,9 +96,19 @@ public sealed class ProcessAudioMessageHandler : IRequestHandler<ProcessAudioMes
                 llmResponse, replyToken, tenantId, lineUserId, cancellationToken);
             _logger.LogInformation("成功處理語音訊息並回覆");
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("請求已取消");
+            throw; // 重新拋出讓 middleware 處理
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Gemini HTTP 呼叫失敗");
+            await SafeReplyAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Gemini API 呼叫失敗");
+            _logger.LogError(ex, "處理訊息時發生非預期錯誤");
             await SafeReplyAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);
         }
     }

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessAudio/ProcessAudioMessageHandler.cs
@@ -103,7 +103,7 @@ public sealed class ProcessAudioMessageHandler : IRequestHandler<ProcessAudioMes
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogError(ex, "Gemini HTTP 呼叫失敗");
+            _logger.LogError(ex, "AI HTTP 呼叫失敗");
             await SafeReplyAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);
         }
         catch (Exception ex)

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs
@@ -69,9 +69,26 @@ public sealed class ProcessTextMessageHandler : IRequestHandler<ProcessTextMessa
                 llmResponse, replyToken, tenantId, lineUserId, cancellationToken);
             _logger.LogInformation("成功處理文字訊息並回覆");
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("請求已取消");
+            throw; // 重新拋出讓 middleware 處理
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Gemini HTTP 呼叫失敗");
+            try
+            {
+                await _lineReplyService.ReplyTextAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);
+            }
+            catch (Exception replyEx)
+            {
+                _logger.LogWarning(replyEx, "LINE Reply 失敗，無法回覆使用者");
+            }
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Gemini API 呼叫失敗");
+            _logger.LogError(ex, "處理訊息時發生非預期錯誤");
             try
             {
                 await _lineReplyService.ReplyTextAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);

--- a/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/LineEvents/ProcessText/ProcessTextMessageHandler.cs
@@ -76,7 +76,7 @@ public sealed class ProcessTextMessageHandler : IRequestHandler<ProcessTextMessa
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogError(ex, "Gemini HTTP 呼叫失敗");
+            _logger.LogError(ex, "AI HTTP 呼叫失敗");
             try
             {
                 await _lineReplyService.ReplyTextAsync(replyToken, "系統忙碌中，請稍後重試", cancellationToken);

--- a/VeggieAlly/src/VeggieAlly.Application/Menu/Publish/PublishMenuCommand.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Menu/Publish/PublishMenuCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using VeggieAlly.Domain.Models.Menu;
+
+namespace VeggieAlly.Application.Menu.Publish;
+
+public sealed record PublishMenuCommand(string TenantId, string LineUserId) : IRequest<PublishedMenu>;

--- a/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
@@ -359,7 +359,7 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
                 {
                     ["type"] = "uri",
                     ["label"] = "✏️ 修正",
-                    ["uri"] = $"{liffBaseUrl}?item_id={item.Id}&field=buy_price"
+                    ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}"
                 }
             });
         }

--- a/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
@@ -350,16 +350,39 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
         // 添加 LIFF 修正按鈕 (如果有 liffBaseUrl)
         if (!string.IsNullOrWhiteSpace(liffBaseUrl))
         {
+            // 建立兩個按鈕：修正進貨價、修正售價
             contents.Add(new Dictionary<string, object>
             {
-                ["type"] = "button",
-                ["height"] = "sm",
-                ["style"] = "secondary",
-                ["action"] = new Dictionary<string, object>
+                ["type"] = "box",
+                ["layout"] = "horizontal",
+                ["spacing"] = "sm",
+                ["margin"] = "xs",
+                ["contents"] = new List<object>
                 {
-                    ["type"] = "uri",
-                    ["label"] = "✏️ 修正",
-                    ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}"
+                    new Dictionary<string, object>
+                    {
+                        ["type"] = "button",
+                        ["height"] = "sm",
+                        ["style"] = "secondary",
+                        ["action"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "uri",
+                            ["label"] = "✏️ 修正進價",
+                            ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}&field=buy_price"
+                        }
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["type"] = "button",
+                        ["height"] = "sm",
+                        ["style"] = "secondary",
+                        ["action"] = new Dictionary<string, object>
+                        {
+                            ["type"] = "uri",
+                            ["label"] = "✏️ 修正售價",
+                            ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}&field=sell_price"
+                        }
+                    }
                 }
             });
         }

--- a/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/FlexMessageBuilder.cs
@@ -368,7 +368,7 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
                         {
                             ["type"] = "uri",
                             ["label"] = "✏️ 修正進價",
-                            ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}&field=buy_price"
+                            ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={Uri.EscapeDataString(item.BuyPrice.ToString(System.Globalization.CultureInfo.InvariantCulture))}&sellPrice={Uri.EscapeDataString(item.SellPrice.ToString(System.Globalization.CultureInfo.InvariantCulture))}&field=buy_price"
                         }
                     },
                     new Dictionary<string, object>
@@ -380,7 +380,7 @@ public sealed class FlexMessageBuilder : IFlexMessageBuilder
                         {
                             ["type"] = "uri",
                             ["label"] = "✏️ 修正售價",
-                            ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}&field=sell_price"
+                            ["uri"] = $"{liffBaseUrl}/numpad?itemId={Uri.EscapeDataString(item.Id.ToString())}&itemName={Uri.EscapeDataString(item.Name)}&buyPrice={Uri.EscapeDataString(item.BuyPrice.ToString(System.Globalization.CultureInfo.InvariantCulture))}&sellPrice={Uri.EscapeDataString(item.SellPrice.ToString(System.Globalization.CultureInfo.InvariantCulture))}&field=sell_price"
                         }
                     }
                 }

--- a/VeggieAlly/src/VeggieAlly.Application/Services/ValidationReplyService.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/ValidationReplyService.cs
@@ -114,7 +114,26 @@ public sealed class ValidationReplyService : IValidationReplyService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "LINE Reply 失敗，無法回覆使用者");
+            _logger.LogWarning(ex, "LINE Reply 主要流程失敗，嘗試 fallback");
+            
+            // 嘗試 fallback 處理
+            try
+            {
+                var fallbackMessage = validatedItems is not null 
+                    ? GenerateValidationReply(validatedItems)
+                    : fallbackText ?? "系統忙碌中，請稍後重試";
+                    
+                // TODO: 在此處實作 LINE Push Message API 作為 fallback
+                // await _linePushService.PushMessageAsync(lineUserId, fallbackMessage, ct);
+                
+                _logger.LogWarning("LINE Reply 失敗但草稿已建立，用戶可能未收到回覆。LineUserId: {LineUserId}, TenantId: {TenantId}", 
+                    lineUserId ?? "unknown", tenantId ?? "unknown");
+            }
+            catch (Exception fallbackEx)
+            {
+                _logger.LogWarning(fallbackEx, "LINE Reply fallback 也失敗，用戶未收到任何回覆。LineUserId: {LineUserId}, TenantId: {TenantId}", 
+                    lineUserId ?? "unknown", tenantId ?? "unknown");
+            }
         }
     }
 

--- a/VeggieAlly/src/VeggieAlly.Application/Services/ValidationReplyService.cs
+++ b/VeggieAlly/src/VeggieAlly.Application/Services/ValidationReplyService.cs
@@ -112,6 +112,10 @@ public sealed class ValidationReplyService : IValidationReplyService
                 await _lineReplyService.ReplyTextAsync(replyToken, fallbackText!, ct);
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "LINE Reply 主要流程失敗，嘗試 fallback");
@@ -119,10 +123,6 @@ public sealed class ValidationReplyService : IValidationReplyService
             // 嘗試 fallback 處理
             try
             {
-                var fallbackMessage = validatedItems is not null 
-                    ? GenerateValidationReply(validatedItems)
-                    : fallbackText ?? "系統忙碌中，請稍後重試";
-                    
                 // TODO: 在此處實作 LINE Push Message API 作為 fallback
                 // await _linePushService.PushMessageAsync(lineUserId, fallbackMessage, ct);
                 

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/DependencyInjection.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/DependencyInjection.cs
@@ -60,7 +60,10 @@ public static class DependencyInjection
         }
         else
         {
-            services.AddSingleton<IDraftSessionStore, InMemoryDraftSessionStore>();
+            var inMemoryStore = new InMemoryDraftSessionStore();
+            services.AddSingleton<IDraftSessionStore>(inMemoryStore);
+            services.AddSingleton(inMemoryStore); // 為 CleanupService 提供具體型別
+            services.AddHostedService<InMemoryDraftSessionCleanupService>();
         }
 
         // ── Draft Menu Service ──

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs
@@ -83,34 +83,40 @@ public sealed class PublishedMenuRepository : IPublishedMenuRepository
 
             await connection.ExecuteAsync(menuSql, menu, transaction);
 
-            // 批次插入菜單品項
-            var itemSql = """
-                INSERT INTO published_menu_items (
-                    id, menu_id, tenant_id, name, is_new, buy_price, sell_price, 
-                    original_qty, remaining_qty, unit, historical_avg_price
-                )
-                VALUES (
-                    @Id, @MenuId, @TenantId, @Name, @IsNew, @BuyPrice, @SellPrice, 
-                    @OriginalQty, @RemainingQty, @Unit, @HistoricalAvgPrice
-                )
-                """;
-
-            var itemParams = menu.Items.Select(item => new
+            // 真正批次插入菜單品項（單一 SQL 語句 + 多 VALUES）
+            if (menu.Items.Count > 0)
             {
-                Id = item.Id,
-                MenuId = item.MenuId,
-                TenantId = menu.TenantId, // 為安全考量，使用菜單的 TenantId
-                Name = item.Name,
-                IsNew = item.IsNew,
-                BuyPrice = item.BuyPrice,
-                SellPrice = item.SellPrice,
-                OriginalQty = item.OriginalQty,
-                RemainingQty = item.RemainingQty,
-                Unit = item.Unit,
-                HistoricalAvgPrice = item.HistoricalAvgPrice
-            }).ToArray();
+                var parameters = new DynamicParameters();
+                var valueClauses = new List<string>();
+                int i = 0;
+                
+                foreach (var item in menu.Items)
+                {
+                    valueClauses.Add($"(@Id{i}, @MenuId{i}, @TenantId{i}, @Name{i}, @IsNew{i}, @BuyPrice{i}, @SellPrice{i}, @OriginalQty{i}, @RemainingQty{i}, @Unit{i}, @HistoricalAvgPrice{i})");
+                    parameters.Add($"Id{i}", item.Id);
+                    parameters.Add($"MenuId{i}", item.MenuId);
+                    parameters.Add($"TenantId{i}", menu.TenantId); // 為安全考量，使用菜單的 TenantId
+                    parameters.Add($"Name{i}", item.Name);
+                    parameters.Add($"IsNew{i}", item.IsNew);
+                    parameters.Add($"BuyPrice{i}", item.BuyPrice);
+                    parameters.Add($"SellPrice{i}", item.SellPrice);
+                    parameters.Add($"OriginalQty{i}", item.OriginalQty);
+                    parameters.Add($"RemainingQty{i}", item.RemainingQty);
+                    parameters.Add($"Unit{i}", item.Unit);
+                    parameters.Add($"HistoricalAvgPrice{i}", item.HistoricalAvgPrice);
+                    i++;
+                }
 
-            await connection.ExecuteAsync(itemSql, itemParams, transaction);
+                var batchItemSql = $"""
+                    INSERT INTO published_menu_items (
+                        id, menu_id, tenant_id, name, is_new, buy_price, sell_price, 
+                        original_qty, remaining_qty, unit, historical_avg_price
+                    )
+                    VALUES {string.Join(", ", valueClauses)}
+                    """;
+
+                await connection.ExecuteAsync(batchItemSql, parameters, transaction);
+            }
 
             await transaction.CommitAsync(ct);
         }

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Persistence/PublishedMenuRepository.cs
@@ -83,7 +83,7 @@ public sealed class PublishedMenuRepository : IPublishedMenuRepository
 
             await connection.ExecuteAsync(menuSql, menu, transaction);
 
-            // 插入菜單品項
+            // 批次插入菜單品項
             var itemSql = """
                 INSERT INTO published_menu_items (
                     id, menu_id, tenant_id, name, is_new, buy_price, sell_price, 
@@ -95,23 +95,22 @@ public sealed class PublishedMenuRepository : IPublishedMenuRepository
                 )
                 """;
 
-            foreach (var item in menu.Items)
+            var itemParams = menu.Items.Select(item => new
             {
-                await connection.ExecuteAsync(itemSql, new
-                {
-                    Id = item.Id,
-                    MenuId = item.MenuId,
-                    TenantId = menu.TenantId, // 為安全考量，使用菜單的 TenantId
-                    Name = item.Name,
-                    IsNew = item.IsNew,
-                    BuyPrice = item.BuyPrice,
-                    SellPrice = item.SellPrice,
-                    OriginalQty = item.OriginalQty,
-                    RemainingQty = item.RemainingQty,
-                    Unit = item.Unit,
-                    HistoricalAvgPrice = item.HistoricalAvgPrice
-                }, transaction);
-            }
+                Id = item.Id,
+                MenuId = item.MenuId,
+                TenantId = menu.TenantId, // 為安全考量，使用菜單的 TenantId
+                Name = item.Name,
+                IsNew = item.IsNew,
+                BuyPrice = item.BuyPrice,
+                SellPrice = item.SellPrice,
+                OriginalQty = item.OriginalQty,
+                RemainingQty = item.RemainingQty,
+                Unit = item.Unit,
+                HistoricalAvgPrice = item.HistoricalAvgPrice
+            }).ToArray();
+
+            await connection.ExecuteAsync(itemSql, itemParams, transaction);
 
             await transaction.CommitAsync(ct);
         }

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/InMemoryDraftSessionCleanupService.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/InMemoryDraftSessionCleanupService.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace VeggieAlly.Infrastructure.Storage;
+
+/// <summary>
+/// InMemory Draft Session 定期清除服務
+/// </summary>
+public sealed class InMemoryDraftSessionCleanupService : BackgroundService
+{
+    private readonly InMemoryDraftSessionStore _store;
+    private readonly ILogger<InMemoryDraftSessionCleanupService> _logger;
+    private readonly TimeSpan _cleanupInterval = TimeSpan.FromMinutes(5);
+
+    public InMemoryDraftSessionCleanupService(
+        InMemoryDraftSessionStore store,
+        ILogger<InMemoryDraftSessionCleanupService> logger)
+    {
+        _store = store;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("InMemory Draft Session 清除服務已啟動");
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(_cleanupInterval, stoppingToken);
+                
+                var removedCount = _store.RemoveExpiredEntries();
+                if (removedCount > 0)
+                {
+                    _logger.LogDebug("已清除 {RemovedCount} 個過期 Draft Session", removedCount);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // 正常停止
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "InMemory Draft Session 清除服務發生錯誤");
+        }
+        finally
+        {
+            _logger.LogInformation("InMemory Draft Session 清除服務已停止");
+        }
+    }
+}

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/InMemoryDraftSessionStore.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/InMemoryDraftSessionStore.cs
@@ -61,6 +61,35 @@ public sealed class InMemoryDraftSessionStore : IDraftSessionStore
     private static string BuildKey(string tenantId, string lineUserId, DateOnly date)
         => $"{tenantId}:draft:{lineUserId}:{date:yyyy-MM-dd}";
 
+    /// <summary>
+    /// 移除所有過期的 Draft Session 項目
+    /// </summary>
+    /// <returns>移除的項目數量</returns>
+    internal int RemoveExpiredEntries()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var expiredKeys = new List<string>();
+
+        foreach (var kvp in _store)
+        {
+            if (kvp.Value.Expiry < now)
+            {
+                expiredKeys.Add(kvp.Key);
+            }
+        }
+
+        var removedCount = 0;
+        foreach (var key in expiredKeys)
+        {
+            if (_store.TryRemove(key, out _))
+            {
+                removedCount++;
+            }
+        }
+
+        return removedCount;
+    }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/RedisDraftSessionStore.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/RedisDraftSessionStore.cs
@@ -28,7 +28,8 @@ public sealed class RedisDraftSessionStore : IDraftSessionStore
         
         try
         {
-            var json = await _database.StringGetAsync(key);
+            var jsonTask = _database.StringGetAsync(key);
+            var json = await jsonTask.WaitAsync(ct);
             if (!json.HasValue)
                 return null;
 
@@ -39,7 +40,8 @@ public sealed class RedisDraftSessionStore : IDraftSessionStore
         {
             _logger.LogWarning(ex, "Redis 草稿反序列化失敗，Key: {Key}", key);
             // 移除損壞的資料
-            await _database.KeyDeleteAsync(key);
+            var deleteTask = _database.KeyDeleteAsync(key);
+            await deleteTask.WaitAsync(ct);
             return null;
         }
         catch (Exception ex)
@@ -56,7 +58,8 @@ public sealed class RedisDraftSessionStore : IDraftSessionStore
         try
         {
             var json = JsonSerializer.Serialize(session, JsonOptions);
-            await _database.StringSetAsync(key, json, TimeSpan.FromHours(24));
+            var setTask = _database.StringSetAsync(key, json, TimeSpan.FromHours(24));
+            await setTask.WaitAsync(ct);
         }
         catch (Exception ex)
         {
@@ -71,7 +74,8 @@ public sealed class RedisDraftSessionStore : IDraftSessionStore
         
         try
         {
-            await _database.KeyDeleteAsync(key);
+            var deleteTask = _database.KeyDeleteAsync(key);
+            await deleteTask.WaitAsync(ct);
         }
         catch (Exception ex)
         {

--- a/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/RedisDraftSessionStore.cs
+++ b/VeggieAlly/src/VeggieAlly.Infrastructure/Storage/RedisDraftSessionStore.cs
@@ -44,6 +44,10 @@ public sealed class RedisDraftSessionStore : IDraftSessionStore
             await deleteTask.WaitAsync(ct);
             return null;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Redis 讀取草稿失敗，Key: {Key}", key);

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/FlexMessageBuilderTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/FlexMessageBuilderTests.cs
@@ -157,7 +157,10 @@ public sealed class FlexMessageBuilderTests
         var json = Serialize(_builder.BuildDraftBubble(session, "https://liff.line.me/1234"));
 
         json.Should().Contain("✏️ 修正");
-        json.Should().Contain("item_id=a1b2c3d4e5f67890a1b2c3d4e5f67890");
+        json.Should().Contain("itemId=a1b2c3d4e5f67890a1b2c3d4e5f67890");
+        json.Should().Contain("itemName=%E5%88%9D%E7%A7%8B%E9%AB%98%E9%BA%97%E8%8F%9C");
+        json.Should().Contain("buyPrice=50");
+        json.Should().Contain("sellPrice=40");
         json.Should().Contain("uri");
     }
 

--- a/VeggieAlly/tests/VeggieAlly.Application.Tests/FlexMessageBuilderTests.cs
+++ b/VeggieAlly/tests/VeggieAlly.Application.Tests/FlexMessageBuilderTests.cs
@@ -161,6 +161,8 @@ public sealed class FlexMessageBuilderTests
         json.Should().Contain("itemName=%E5%88%9D%E7%A7%8B%E9%AB%98%E9%BA%97%E8%8F%9C");
         json.Should().Contain("buyPrice=50");
         json.Should().Contain("sellPrice=40");
+        json.Should().Contain("field=buy_price");
+        json.Should().Contain("field=sell_price");
         json.Should().Contain("uri");
     }
 


### PR DESCRIPTION
Addresses all code review feedback raised against the M-2~M-9 medium issue fix PR.

## Changes

**Correctness / graceful shutdown**
- `ValidationReplyService`: add `catch (OperationCanceledException) { throw; }` before the swallowing outer `catch (Exception)` so cancellation propagates; remove the unused `fallbackMessage` local (would fail `TreatWarningsAsErrors=true`)
- `RedisDraftSessionStore.GetAsync`: same `OperationCanceledException` rethrow before the general catch that previously returned `null` on cancellation

**Culture safety**
- `FlexMessageBuilder`: price values in LIFF numpad URLs were interpolated as raw `decimal`, making them culture-dependent. Now formatted with `CultureInfo.InvariantCulture` and wrapped in `Uri.EscapeDataString`:
  ```csharp
  // before
  $"...&buyPrice={item.BuyPrice}&sellPrice={item.SellPrice}&..."
  // after
  $"...&buyPrice={Uri.EscapeDataString(item.BuyPrice.ToString(CultureInfo.InvariantCulture))}&..."
  ```

**Log accuracy**
- `ProcessTextMessageHandler` / `ProcessAudioMessageHandler`: hard-coded `"Gemini"` in `HttpRequestException` log messages replaced with provider-neutral `"AI"`

**Frontend**
- `NumPadPage.vue`: `console.warn` moved from inside `computed` (runs on every reactive re-evaluation) to `onMounted` (fires once); `computed` is now a pure expression

**Tests**
- `FlexMessageBuilderTests`: added assertions for `field=buy_price` and `field=sell_price` to cover the full LIFF button URL contract

**Build fix**
- Added missing `PublishMenuCommand.cs` record that caused a pre-existing build failure (`PublishMenuHandler` referenced it but the file was absent)