### PR TITLE
feat(orchestrator): 新增任務分級規則（L1/L2/L3）與 Git-as-Memory 強制原則

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -57,7 +57,7 @@ Issue、Branch、PR、Commit history 是跨 session 的唯一可追溯機制。
 
 | 等級 | 判斷條件 | 執行者 |
 |------|----------|--------|
-| **L1 輕量** | 純配置／文件變更、無跨域影響、單一檔案或少量檔案 | Orchestrator 直接執行 |
+| **L1 輕量** | 純配置／文件變更、無跨域影響、單一檔案或少量檔案 | Orchestrator 直接處理（限非程式碼） |
 | **L2 標準** | 涉及程式碼、API contract、DB schema 其中之一 | 分派給對應專家 Agent |
 | **L3 複雜** | 跨多個 agent 職責、需要並行開發 | worktree 並行，多 Agent 協作 |
 
@@ -65,7 +65,7 @@ Issue、Branch、PR、Commit history 是跨 session 的唯一可追溯機制。
 
 > 任務分級：**L{N}**
 > 理由：{一句話說明判斷依據}
-> 執行方式：{Orchestrator 直接執行 / 分派給 xxx Agent / worktree 並行}
+> 執行方式：{Orchestrator 直接處理（限非程式碼） / 分派給 {SA/SD/QA/QC/backend-pg/frontend-pg/DBA/e2e-test} / worktree 並行}
 
 ### 階段二：任務路由 (Task Routing)
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -47,6 +47,26 @@ argument-hint: "描述你的需求、問題或要協調的任務"
 5. 確認合理後，在 GitHub 建立 Issue（含精煉後的問題陳述、驗收標準）
 6. 從 main 切出 feature branch，命名引用 Issue 編號：`feature/{issue-no}-{short-name}`
 
+### 階段一．五：任務分級 (Task Classification)
+
+**核心原則：Git 是 multi-agent 團隊的唯一持久記憶體。**
+Issue、Branch、PR、Commit history 是跨 session 的唯一可追溯機制。
+**因此，無論任何等級，Issue + Feature Branch 一律必建，不得跳過。**
+
+依需求性質分為三個等級，決定執行方式：
+
+| 等級 | 判斷條件 | 執行者 |
+|------|----------|--------|
+| **L1 輕量** | 純配置／文件變更、無跨域影響、單一檔案或少量檔案 | Orchestrator 直接執行 |
+| **L2 標準** | 涉及程式碼、API contract、DB schema 其中之一 | 分派給對應專家 Agent |
+| **L3 複雜** | 跨多個 agent 職責、需要並行開發 | worktree 並行，多 Agent 協作 |
+
+**分級聲明格式**（每次必須明確輸出）：
+
+> 任務分級：**L{N}**
+> 理由：{一句話說明判斷依據}
+> 執行方式：{Orchestrator 直接執行 / 分派給 xxx Agent / worktree 並行}
+
 ### 階段二：任務路由 (Task Routing)
 
 1. 將精煉後的需求轉換為高階架構分析任務


### PR DESCRIPTION
## 功能摘要

補充 Orchestrator 在需求淨化後的任務分級機制，確保：
- 所有等級任務一律建立 Issue + Branch（Git-as-Memory 原則）
- L1 輕量任務由 Orchestrator 直接執行
- L2/L3 任務分派給專家 Agent 或 worktree 並行

## 變更清單

- `.github/agents/orchestrator.agent.md`：新增「階段一．五：任務分級」章節

## Agent 產出

- general-purpose agent：執行檔案修改與 commit

## QA/QC 驗證

N/A（純文件規則變更，無程式碼邏輯）

## 安全驗證摘要

無安全相關變更

Close #30