### PR TITLE
Docs: 補入 L0 外部阻塞分級與 threat-model-analyst 路由規則

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -95,6 +95,7 @@ description: Multi-agent team coordination rules for enterprise software develop
 
 | 等級 | 判斷條件 | 執行者 |
 |------|----------|--------|
+| **L0 外部阻塞** | 完全或部分依賴人類或外部資源（實體設備、法律身份、外部系統帳號、金錢支出、實體訪談等，詳見 ADR-001 §Human-in-the-Loop 三層漏斗） | 建 issue、標 `cap:human` + `status:blocked`，觸發三重通知 |
 | **L1 輕量** | 純文件 / 設定變更、無跨域影響、無任何程式碼異動 | Orchestrator 直接處理 |
 | **L2 標準** | 涉及程式碼、API contract、DB schema 其中之一 | 分派給對應專家 Agent |
 | **L3 複雜** | 跨多個 agent 職責、需要並行開發 | worktree 並行,多 Agent 協作 |
@@ -130,6 +131,7 @@ description: Multi-agent team coordination rules for enterprise software develop
 | 規格已定、需建表/改表 | DBA |
 | 交付物需 API 驗證 | QA/QC |
 | 需進行全系統 UI 核心流程測試 | E2E 測試 |
+| 需進行 STRIDE-A 威脅建模分析或增量更新（含 /threat-model-analyst 直接呼叫） | threat-model-analyst skill |
 | 規格有爭議或矛盾 | SA/SD(重新設計) |
 
 **Worktree 並行規則**:


### PR DESCRIPTION
## 功能摘要
補齊 `.github/AGENTS.md` 與 ADR-001 的落差：任務分級表加入 L0 外部阻塞列，Orchestrator 分派邏輯表加入 threat-model-analyst 路由行。CH-3 目錄結構已存在，無需變更。

## 涉及的 Agent 產出
- Orchestrator：需求淨化、任務分級（L2）、AGENTS.md 編輯執行
- SA/SD：驗證 L0 定義與 ADR-001 對齊、產出精確插入規格

## 變更明細（+2 行，-0 行）
| 編號 | 位置 | 說明 |
|------|------|------|
| CH-1 | 任務分級表（第 98 行） | 補入 L0 外部阻塞列，定義對齊 ADR-001 §Human-in-the-Loop |
| CH-2 | 分派邏輯表（第 134 行） | 補入 threat-model-analyst skill 路由行 |
| CH-3 | 目錄結構（第 235 行） | 已存在，無需變更 |

## QA/QC 驗證結果
- 結果：純文件變更（+2 行），無程式碼影響，無 DB schema 異動
- 人工確認：diff 僅 2 行插入，與 ADR-001 定義完全一致，無內容刪除

## 安全驗證摘要
- Critical / High 缺陷：0（阻擋：否）
- Medium / Low 缺陷：0
- 禁止豁免命中：無
- 安全標籤：全部未勾選（純治理文件補齊）

## ⚠️ MUST-READ 說明
本次新增 L0 分類行與 threat-model-analyst 路由行，影響 Orchestrator 後續的任務分級與路由決策。所有 Agent 在下次 session 應重讀 AGENTS.md §任務分級 與 §路由規則。

## 本次引用的 ADR
- ADR: docs/specs/adr/ADR-001-multi-agent-workflow-progressive-adoption.md

closes #49