### PR TITLE
Refactor: Remove hardcoded ADR-001 references for cross-project portability

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -95,7 +95,7 @@ description: Multi-agent team coordination rules for enterprise software develop
 
 | 等級 | 判斷條件 | 執行者 |
 |------|----------|--------|
-| **L0 外部阻塞** | 完全或部分依賴人類或外部資源（實體設備、法律身份、外部系統帳號、金錢支出、實體訪談等；操作規則見 `.github/agents/orchestrator.agent.md §階段一.六 / §階段一.七`，決策脈絡見 ADR-001） | 建 issue、標 `cap:human` + `status:blocked`，觸發三重通知 |
+| **L0 外部阻塞** | 完全或部分依賴人類或外部資源（實體設備、法律身份、外部系統帳號、金錢支出、實體訪談等；操作規則見 `.github/agents/orchestrator.agent.md §階段一.六 / §階段一.七`，若本專案有記錄對應決策脈絡請於 `docs/specs/adr/` 查閱） | 建 issue、標 `cap:human` + `status:blocked`，觸發三重通知 |
 | **L1 輕量** | 純文件 / 設定變更、無跨域影響、無任何程式碼異動 | Orchestrator 直接處理 |
 | **L2 標準** | 涉及程式碼、API contract、DB schema 其中之一 | 分派給對應專家 Agent |
 | **L3 複雜** | 跨多個 agent 職責、需要並行開發 | worktree 並行,多 Agent 協作 |

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -107,7 +107,7 @@ body:
       label: 外部協作需求 (Human-in-the-Loop) — 三層漏斗判斷
       description: |
         建立者可先勾選,Orchestrator 於需求淨化時確認或修正;若不確定可先留空。
-        勾選任一項代表需拆出 `cap:human` 子 issue,並以 `depends-on` 鎖住後續任務。詳細判準見 ADR-001。
+        勾選任一項代表需拆出 `cap:human` 子 issue,並以 `depends-on` 鎖住後續任務。詳細判準見 `.github/agents/orchestrator.agent.md §階段一.六`。
       options:
         - label: 第一層(能不能做)— 需實體設備 / 法律身份 / 外部帳號 / 金錢支出 / 實體訪談
         - label: 第二層(該不該做)— 不可逆決策 / 品牌形象 / 法規 / 美感 / 跨角色共識

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -91,7 +91,7 @@ Issue、Branch、PR、Commit history 是跨 session 的唯一可追溯機制。
 | **L2 標準** | 涉及程式碼、API contract、DB schema 其中之一 | 分派給對應專家 Agent |
 | **L3 複雜** | 跨多個 agent 職責、需要並行開發 | worktree 並行,多 Agent 協作 |
 
-> L0 的判定規則、嚴格使用原則與通知機制見 §階段一.六、§階段一.七;決策脈絡見 [ADR-001](../../docs/specs/adr/ADR-001-multi-agent-workflow-progressive-adoption.md)。
+> L0 的判定規則、嚴格使用原則與通知機制見 §階段一.六、§階段一.七;若本專案有記錄對應架構決策,請於專案 `docs/specs/adr/` 查閱。
 
 #### L1 範疇明細(白名單)
 
@@ -138,7 +138,7 @@ Issue、Branch、PR、Commit history 是跨 session 的唯一可追溯機制。
 
 ### 階段一.六:Human-in-the-Loop 三層漏斗(L0 判定)
 
-> 📖 本章節為操作規則;決策脈絡與 Phase 演進路徑見 [ADR-001](../../docs/specs/adr/ADR-001-multi-agent-workflow-progressive-adoption.md)。
+> 📖 本章節為操作規則;若本專案有記錄此機制的採用脈絡或 Phase 演進路徑,請於專案 `docs/specs/adr/` 查閱對應 ADR。
 
 在階段一需求淨化時,依序套用三層漏斗;**任一層命中即標 `cap:human`,分級為 L0**。
 


### PR DESCRIPTION
Closes #55

## 功能摘要
移除 `.github/` 下三份檔案中對 `ADR-001` 的硬編碼引用，改為專案中性描述，確保 multi-agent 規則集可跨專案復用。

## 變更內容

| 檔案 | 變更 |
|------|------|
| `.github/agents/orchestrator.agent.md` | 兩處（§階段一.五 L0 註記 / §階段一.六 開頭）ADR-001 連結改為引導到專案自身 `docs/specs/adr/` |
| `.github/AGENTS.md` | L0 分級表格內的 ADR-001 引用改為中性描述 |
| `.github/ISSUE_TEMPLATE/feature.yml` | HITL 漏斗 description 的 ADR-001 引用改為 `.github/agents/orchestrator.agent.md §階段一.六` |

## 動機

Agent 檔案 + AGENTS.md + ISSUE_TEMPLATE 是 multi-agent 規則集，應該可整包移植到其他專案。硬編碼 ADR-001 會：
- 導致移植後連結失效
- 洩漏本專案特定的 Phase 1/2/3 導入策略語意
- 違反 ADR（Why，專案特定）與 Agent/規則檔案（How，跨專案通用）的分離原則

本專案的 HITL 決策脈絡仍保留在 ADR-001，由 Orchestrator 的階段零 ADR 歷史查詢自動發現。

## QA/QC 驗證結果
L1 純文字修訂，無實作碼異動。`grep 'ADR-001'` 驗證三份檔案已無殘留引用。

## 安全驗證摘要
- 安全標籤：**涉及 AI / LLM 功能**（修改 multi-agent 協作設計文件）
- LLM06 Excessive Agency：無影響（僅文字引用調整，未變更工具白名單、權限、HITL 觸發條件）
- LLM07 System Prompt Leakage：無影響

## 任務分級
**L1** — 純 `.md` / `.yml` description 文字修訂，符合 L1 白名單。

## 待人類處理事項
- [x] 人類批准合併（Orchestrator 不自行 merge）