### PR TITLE
feat(auth): 新增 FallbackPolicy 全域認證強制執行 (#60)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -200,6 +200,24 @@ description: Multi-agent team coordination rules for enterprise software develop
 
 > 📖 **相關 Skill**：詳見 ADR-002-qa-qc-blueprint-review-gate.md 與 `.github/skills/bdd-conventions/SKILL.md`
 
+## 後端 PG 編碼規範
+
+### ⚠️ 授權標注強制規則（FallbackPolicy 安全防線）
+
+`Program.cs` 已設定 `FallbackPolicy = RequireAuthenticatedUser()`。
+**後端 PG 新增 Controller class 或 Action method 時，必須明確標注以下其中一個授權屬性，不得省略：**
+
+| 情境 | 使用屬性 | 說明 |
+|------|----------|------|
+| LIFF 端點（LINE 使用者操作） | `[LiffAuth]` | 驗證 LINE Bearer Token |
+| LINE Webhook 端點 | `[TypeFilter(typeof(LineSignatureAuthFilter))]` | 驗證 LINE Channel Secret 簽名 |
+| 明確公開端點（需說明理由） | `[AllowAnonymous]` | 需在 PR 描述中說明為何公開 |
+| 使用 ASP.NET Core 內建 JWT | `[Authorize]` | 標準授權管道 |
+
+**違反後果**：未標注的 endpoint 在所有環境一律返回 401，上線即故障。
+
+---
+
 ## 平行施工規則
 
 SA/SD 藍圖交付後,前端 PG、後端 PG、DBA 三者**同時啟動**,互不阻塞:

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -207,14 +207,16 @@ description: Multi-agent team coordination rules for enterprise software develop
 `Program.cs` 已設定 `FallbackPolicy = RequireAuthenticatedUser()`。
 **後端 PG 新增 Controller class 或 Action method 時，必須明確標注以下其中一個授權屬性，不得省略：**
 
-| 情境 | 使用屬性 | 說明 |
-|------|----------|------|
-| LIFF 端點（LINE 使用者操作） | `[LiffAuth]` | 驗證 LINE Bearer Token |
-| LINE Webhook 端點 | `[TypeFilter(typeof(LineSignatureAuthFilter))]` | 驗證 LINE Channel Secret 簽名 |
-| 明確公開端點（需說明理由） | `[AllowAnonymous]` | 需在 PR 描述中說明為何公開 |
-| 使用 ASP.NET Core 內建 JWT | `[Authorize]` | 標準授權管道 |
+| 情境 | class 層標注 | method 層標注 | 說明 |
+|------|-------------|--------------|------|
+| LIFF 端點（LINE 使用者操作） | `[AllowAnonymous]` | `[LiffAuth]` | class 讓 FallbackPolicy 跳過；method 執行 LINE Bearer Token 驗證 |
+| LINE Webhook 端點 | `[AllowAnonymous]` | `[TypeFilter(typeof(LineSignatureAuthFilter))]` | class 讓 FallbackPolicy 跳過；method 執行 Channel Secret 簽名驗證 |
+| 使用 ASP.NET Core 內建 JWT | `[Authorize]` | 可省略（繼承 class） | 使用 ASP.NET Core 標準授權管道，FallbackPolicy 也可保護 |
+| 明確整個 Controller 公開（需說明理由） | `[AllowAnonymous]` | — | PR 描述中必須說明公開理由 |
 
-**違反後果**：未標注的 endpoint 在所有環境一律返回 401，上線即故障。
+> ⚠️ **LIFF / Webhook Controller 的關鍵陷阱**：`[LiffAuth]` 是 ActionFilter，在 FallbackPolicy 之後執行。若 class 層只加 `[LiffAuth]` 而未加 `[AllowAnonymous]`，FallbackPolicy 會在 ActionFilter 執行前就返回 401。**class 層必須有 `[AllowAnonymous]`，才能讓 custom filter 接管驗證。**
+
+**違反後果**：未依上表標注的 endpoint 在所有環境一律返回 401，上線即故障。
 
 ---
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -211,7 +211,7 @@ description: Multi-agent team coordination rules for enterprise software develop
 |------|-------------|--------------|------|
 | LIFF 端點（LINE 使用者操作） | `[AllowAnonymous]` | `[LiffAuth]` | class 讓 FallbackPolicy 跳過；method 執行 LINE Bearer Token 驗證 |
 | LINE Webhook 端點 | `[AllowAnonymous]` | `[TypeFilter(typeof(LineSignatureAuthFilter))]` | class 讓 FallbackPolicy 跳過；method 執行 Channel Secret 簽名驗證 |
-| 使用 ASP.NET Core 內建 JWT | `[Authorize]` | 可省略（繼承 class） | 使用 ASP.NET Core 標準授權管道，FallbackPolicy 也可保護 |
+| 使用 ASP.NET Core 內建 JWT（僅限 `Program.cs` 已註冊 JWT Bearer） | `[Authorize]` 或 `[Authorize(AuthenticationSchemes = "Bearer")]` | 可省略（繼承 class） | **前提是已註冊 Bearer authentication handler**；否則 `[Authorize]` 只會走目前預設/已註冊 scheme 而返回 401，不能單靠標注屬性啟用 JWT 驗證 |
 | 明確整個 Controller 公開（需說明理由） | `[AllowAnonymous]` | — | PR 描述中必須說明公開理由 |
 
 > ⚠️ **LIFF / Webhook Controller 的關鍵陷阱**：`[LiffAuth]` 是 ActionFilter，在 FallbackPolicy 之後執行。若 class 層只加 `[LiffAuth]` 而未加 `[AllowAnonymous]`，FallbackPolicy 會在 ActionFilter 執行前就返回 401。**class 層必須有 `[AllowAnonymous]`，才能讓 custom filter 接管驗證。**

--- a/.github/agents/backend-pg.agent.md
+++ b/.github/agents/backend-pg.agent.md
@@ -70,8 +70,10 @@ model: Claude Sonnet 4.6
   |------|----------|-----------------|
   | LIFF Controller | `[AllowAnonymous]` | `[LiffAuth]` on each action |
   | Webhook Controller | `[AllowAnonymous]` | `[TypeFilter(typeof(LineSignatureAuthFilter))]` on each action |
-  | JWT 標準授權 | `[Authorize]` | 可省略（繼承） |
+  | JWT 標準授權（**僅限已完成 JWT Bearer 設定後**） | `[Authorize]` | 可省略（繼承） |
   | 整個 Controller 公開 | `[AllowAnonymous]` | — （需在 PR 說明理由）|
+
+  > 註：只有在 `Program.cs` 已註冊 JWT Bearer authentication handler，並將其設為預設驗證方案或在 `[Authorize(AuthenticationSchemes = ...)]` 明確指定時，`[Authorize]` 才能用於 JWT 驗證。若目前僅註冊 `Null` authentication scheme，則 `[Authorize]` 會一律返回 401；此時請將 JWT 視為未啟用的未來擴充模式，而非現行可直接套用的做法。
 - **SSL/TLS 終止**：後端 API 本身不終止 TLS；生產環境由前置層負責（VPS 部署：nginx + Let's Encrypt certbot；雲端部署：Cloud Load Balancer SSL）——Kestrel 不直接對外暴露
 
 ## 🏗️ .NET Clean Architecture 實作規範

--- a/.github/agents/backend-pg.agent.md
+++ b/.github/agents/backend-pg.agent.md
@@ -64,6 +64,11 @@ model: Claude Sonnet 4.6
   - 新增 middleware 時注意順序，Security Headers 必須在 `UseAuthentication()` 之前
 - **Rate Limiting**：每個新的 Controller action 預設繼承全域 Fixed Window（60 req/60s per IP）；查詢個資、財務等敏感列表端點**必須額外加上** `[EnableRateLimiting("sensitive-list")]`（Sliding Window 20 req/60s）
 - **Health Check 豁免**：`/health/live` 與 `/health/ready` 必須保持 `.DisableRateLimiting()`，不受速率限制
+- **FallbackPolicy 強制授權標注（⚠️ 新增 Controller / Action 必讀）**：`Program.cs` 已設定 `FallbackPolicy = RequireAuthenticatedUser()`，任何未標注授權屬性的 endpoint 在所有環境一律返回 401。新增 Controller class 或 Action method 時，**必須**明確標注以下其中一個，不得省略：
+  - `[LiffAuth]`：LIFF 端點，驗證 LINE Bearer Token
+  - `[TypeFilter(typeof(LineSignatureAuthFilter))]`：LINE Webhook 端點，驗證 Channel Secret 簽名
+  - `[AllowAnonymous]`：明確聲明公開端點，**PR 描述中必須說明公開理由**
+  - `[Authorize]`：使用 ASP.NET Core 內建授權管道
 - **SSL/TLS 終止**：後端 API 本身不終止 TLS；生產環境由前置層負責（VPS 部署：nginx + Let's Encrypt certbot；雲端部署：Cloud Load Balancer SSL）——Kestrel 不直接對外暴露
 
 ## 🏗️ .NET Clean Architecture 實作規範

--- a/.github/agents/backend-pg.agent.md
+++ b/.github/agents/backend-pg.agent.md
@@ -64,11 +64,14 @@ model: Claude Sonnet 4.6
   - 新增 middleware 時注意順序，Security Headers 必須在 `UseAuthentication()` 之前
 - **Rate Limiting**：每個新的 Controller action 預設繼承全域 Fixed Window（60 req/60s per IP）；查詢個資、財務等敏感列表端點**必須額外加上** `[EnableRateLimiting("sensitive-list")]`（Sliding Window 20 req/60s）
 - **Health Check 豁免**：`/health/live` 與 `/health/ready` 必須保持 `.DisableRateLimiting()`，不受速率限制
-- **FallbackPolicy 強制授權標注（⚠️ 新增 Controller / Action 必讀）**：`Program.cs` 已設定 `FallbackPolicy = RequireAuthenticatedUser()`，任何未標注授權屬性的 endpoint 在所有環境一律返回 401。新增 Controller class 或 Action method 時，**必須**明確標注以下其中一個，不得省略：
-  - `[LiffAuth]`：LIFF 端點，驗證 LINE Bearer Token
-  - `[TypeFilter(typeof(LineSignatureAuthFilter))]`：LINE Webhook 端點，驗證 Channel Secret 簽名
-  - `[AllowAnonymous]`：明確聲明公開端點，**PR 描述中必須說明公開理由**
-  - `[Authorize]`：使用 ASP.NET Core 內建授權管道
+- **FallbackPolicy 強制授權標注（⚠️ 新增 Controller / Action 必讀）**：`Program.cs` 已設定 `FallbackPolicy = RequireAuthenticatedUser()`，任何未依規標注的 endpoint 在所有環境一律返回 401。**`[LiffAuth]` 是 ActionFilter，在 FallbackPolicy 之後執行**，因此 class 層必須搭配 `[AllowAnonymous]` 讓 FallbackPolicy 跳過，再由 ActionFilter 接管驗證：
+
+  | 情境 | class 層 | method/action 層 |
+  |------|----------|-----------------|
+  | LIFF Controller | `[AllowAnonymous]` | `[LiffAuth]` on each action |
+  | Webhook Controller | `[AllowAnonymous]` | `[TypeFilter(typeof(LineSignatureAuthFilter))]` on each action |
+  | JWT 標準授權 | `[Authorize]` | 可省略（繼承） |
+  | 整個 Controller 公開 | `[AllowAnonymous]` | — （需在 PR 說明理由）|
 - **SSL/TLS 終止**：後端 API 本身不終止 TLS；生產環境由前置層負責（VPS 部署：nginx + Let's Encrypt certbot；雲端部署：Cloud Load Balancer SSL）——Kestrel 不直接對外暴露
 
 ## 🏗️ .NET Clean Architecture 實作規範

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Configuration/NullAuthenticationHandler.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Configuration/NullAuthenticationHandler.cs
@@ -1,0 +1,26 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace VeggieAlly.WebAPI.Configuration;
+
+/// <summary>
+/// 不進行任何驗證的 Null Authentication Handler。
+/// 用於支援 ASP.NET Core 授權管道（FallbackPolicy），
+/// 同時保留現有 ActionFilter 驗證機制不受影響。
+/// 所有已保護的 Controller 須標記 [AllowAnonymous]，由自訂 Filter 負責驗證；
+/// 未標記的新 Controller 將被 FallbackPolicy 阻擋並返回 401。
+/// </summary>
+internal sealed class NullAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public NullAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        => Task.FromResult(AuthenticateResult.NoResult());
+}

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/DraftController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/DraftController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using System.Text.RegularExpressions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,7 @@ namespace VeggieAlly.WebAPI.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/draft")]
+[AllowAnonymous] // 實際驗證由 [LiffAuth] ActionFilter 負責；FallbackPolicy 不介入此 Controller
 public class DraftController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/InventoryController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/InventoryController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using VeggieAlly.Application.Menu.DeductInventory;
@@ -9,6 +10,7 @@ namespace VeggieAlly.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/menu")]
+[AllowAnonymous] // 實際驗證由 [LiffAuth] ActionFilter 負責；FallbackPolicy 不介入此 Controller
 public sealed class InventoryController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/MenuController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/MenuController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using VeggieAlly.Application.Menu.GetToday;
@@ -10,6 +11,7 @@ namespace VeggieAlly.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/menu")]
+[AllowAnonymous] // 實際驗證由 [LiffAuth] ActionFilter 負責；FallbackPolicy 不介入此 Controller
 public sealed class MenuController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/WebhookController.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Controllers/WebhookController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using VeggieAlly.Application.Common.Interfaces;
@@ -12,6 +13,7 @@ namespace VeggieAlly.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[AllowAnonymous] // 實際驗證由 [TypeFilter(typeof(LineSignatureAuthFilter))] 負責；FallbackPolicy 不介入此 Controller
 public sealed class WebhookController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/VeggieAlly/src/VeggieAlly.WebAPI/Program.cs
+++ b/VeggieAlly/src/VeggieAlly.WebAPI/Program.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using VeggieAlly.Application;
 using VeggieAlly.Infrastructure;
 using VeggieAlly.WebAPI.Configuration;
@@ -19,6 +21,22 @@ builder.Services.AddScoped<LineSignatureAuthFilter>();
 
 // ── ASP.NET Core ──
 builder.Services.AddControllers();
+
+// ── 認證 / 授權（Option A：NullHandler + FallbackPolicy）──
+// NullAuthenticationHandler：不實際驗證任何身份，僅讓 UseAuthentication() middleware 正常運行。
+// 現有 Controller 標記 [AllowAnonymous]，實際驗證由 LiffAuthFilter / LineSignatureAuthFilter 負責。
+// 未來新增的 Controller 若未標記 [AllowAnonymous]，FallbackPolicy 將攔截並返回 401。
+const string NullScheme = "Null";
+builder.Services
+    .AddAuthentication(NullScheme)
+    .AddScheme<AuthenticationSchemeOptions, NullAuthenticationHandler>(NullScheme, _ => { });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+});
 
 // ── OpenAPI/Swagger 設定 ──
 builder.Services.AddEndpointsApiExplorer();
@@ -51,6 +69,8 @@ else
     app.UseHttpsRedirection();
 }
 app.UseStaticFiles();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
## 功能摘要

新增 ASP.NET Core `FallbackPolicy = RequireAuthenticatedUser()`，確保任何新增 endpoint 若忘記標注授權屬性，在所有環境一律返回 401，消除因疏忽導致 endpoint 暴露於公網的安全風險。

## 架構設計決策

**選型：NullAuthenticationHandler + FallbackPolicy（非 JWT 整合）**

| 方案 | 說明 | 選擇 |
|------|------|------|
| NullHandler + AllowAnonymous | 現有 custom filter 架構零破壞，快速交付 | ✅ 採用 |
| 遷移至 ASP.NET Core auth handler | 架構更正確，但需重構 LiffAuthFilter | 技術債追蹤 |

現有 `[LiffAuth]` / `[LineSignatureAuthFilter]` 皆為 ActionFilter，在 FallbackPolicy 之後執行，因此現有 4 個 Controller class 層加 `[AllowAnonymous]` 讓 FallbackPolicy 跳過，custom filter 繼續執行實際驗證。

## 變更清單

### 代碼變更（Backend PG — commit `1d42506`）

| 檔案 | 說明 |
|------|------|
| `Configuration/NullAuthenticationHandler.cs` | 新增：回傳 `AuthenticateResult.NoResult()`，讓 `UseAuthentication()` 正常初始化但 User 保持未認證 |
| `Program.cs` | `AddAuthentication(NullScheme)` + `AddAuthorization(FallbackPolicy)` + `UseAuthentication()` + `UseAuthorization()` |
| `DraftController.cs` | class 加 `[AllowAnonymous]` |
| `MenuController.cs` | class 加 `[AllowAnonymous]` |
| `InventoryController.cs` | class 加 `[AllowAnonymous]` |
| `WebhookController.cs` | class 加 `[AllowAnonymous]` |

### 規範文件（Orchestrator — commits `a604534`, `1b141fc`, `e7f9f47`）

| 檔案 | 說明 |
|------|------|
| `.github/AGENTS.md` | 新增「後端 PG 編碼規範 > 授權標注強制規則」章節（雙層標注說明） |
| `.github/agents/backend-pg.agent.md` | 同步新增授權標注強制規則至 Backend PG system prompt |

## QA/QC 驗證結果

**整體結論：✅ 可合併（0 Critical / 0 High）**

### 安全驗證通過項目（9/10）

| 檢查 | 結果 |
|------|------|
| `NoResult()` 語意安全性（無法誤認為 authenticated） | ✅ |
| FallbackPolicy 未標注 Controller → 401 | ✅ |
| `[AllowAnonymous]` 不抑制 ActionFilter 執行 | ✅ |
| Middleware 順序正確（Auth → Authorization → MapControllers） | ✅ |
| Testing env mock bypass 與 FallbackPolicy 相容 | ✅ |
| Production 無法偽造 `X-Test-Auth` 繞過 | ✅ |

### 缺陷清單

| # | 嚴重度 | 說明 | 狀態 |
|---|--------|------|------|
| M-1 | Medium | AGENTS.md 授權規則表格歧義（雙層標注未說明） | ✅ 已修正（commit `e7f9f47`） |
| M-2 | Medium | FallbackPolicy 缺少 WebApplicationFactory 整合測試 | 📋 列入下一 Sprint（Issue #60 追蹤） |
| L-1 | Low | `NullScheme` 常數應移入 `NullAuthenticationHandler` | 📋 Tech Debt |
| L-2 | Low | 缺 ADR 記錄 NullHandler 選型理由 | 📋 Tech Debt |

## 待人類處理事項

無 `cap:human` 依賴。

## 相關 Issue / ADR

- Closes #60
- 架構影響：`⚠️ MUST-READ` — 後端 PG 未來新增 Controller 必須依雙層標注規則（`e7f9f47`）